### PR TITLE
feat(model): add server presign source for pull-model (NUV-222)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,27 @@ curl -fsSL https://apt.plaidai.io/install-apt.sh | bash
 
 Python requirement: 3.10+
 
-## Pull model bundle (GCS bucket)
-GCS pointer를 통해 모델 번들을 내려받아 Triton/AnomalyCLIP 런타임에 바로 연결할 수 있습니다.
+## Pull model bundle (server presign 권장)
+운영 기본 경로는 `NUV-BE` presign API를 통해 signed URL을 받아 모델 번들을 내려받는 방식입니다.
 ```bash
 # runtime: text_features + Triton model_repository (권장)
 nuv-agent pull-model \
+  --source server \
+  --server-base-url https://api.nuvion-dev.plaidai.io \
+  --pointer anomalyclip/prod \
+  --local-dir ~/.cache/nuvion/models/anomalyclip-current \
+  --profile runtime
+```
+
+- `--access-token`을 직접 전달하거나, 생략 시 `NUVION_DEVICE_USERNAME/NUVION_DEVICE_PASSWORD`로 `/auth/login` 후 presign 호출
+- 다운로드 후 각 artifact에 대해 `sha256` 무결성 검증 수행
+- 결과 메타데이터: `metadata/downloaded_from_server.json`
+
+## Pull model bundle (GCS fallback)
+개발/운영 점검용 fallback으로 GCS 직접 pull도 유지됩니다.
+```bash
+nuv-agent pull-model \
+  --source gcs \
   --gcs-pointer-uri gs://nuv-model/pointers/anomalyclip/prod.json \
   --local-dir ~/.cache/nuvion/models/anomalyclip-current \
   --profile runtime
@@ -57,6 +73,10 @@ Profiles:
 - `full`: 추가 분석/검증 파일까지 포함해서 다운로드
 
 기본값:
+- `NUVION_MODEL_SOURCE=server`
+- `NUVION_MODEL_POINTER=anomalyclip/prod`
+- `NUVION_MODEL_PRESIGN_TTL_SECONDS=300`
+- `NUVION_MODEL_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io`
 - `NUVION_MODEL_GCS_POINTER_URI=gs://nuv-model/pointers/anomalyclip/prod.json`
 - `NUVION_MODEL_PROFILE=runtime`
 - `NUVION_MODEL_LOCAL_DIR=~/.cache/nuvion/models/anomalyclip-current`
@@ -146,6 +166,11 @@ For dev, `.env` in the repo is used automatically.
 - `NUVION_ZERO_SHOT_ENABLED`: enable optional zero-shot anomaly detection (requires model deps)
 - `NUVION_ZSAD_BACKEND`: 기본 `triton` (장애 대응 시 `siglip`로 수동 전환 가능)
 - `NUVION_ZERO_SHOT_MODEL`: 기본 ZSAD 모델 (`google/siglip2-base-patch16-224`)
+- `NUVION_MODEL_SOURCE`: `server`(권장) | `gcs`(fallback)
+- `NUVION_MODEL_POINTER`: server source에서 사용할 pointer (`anomalyclip/prod`)
+- `NUVION_MODEL_PRESIGN_TTL_SECONDS`: server source presign 요청 TTL
+- `NUVION_MODEL_SERVER_BASE_URL`: server source presign API base URL
+- `NUVION_MODEL_SERVER_ACCESS_TOKEN`: server source에서 사용할 사전 발급 토큰(선택)
 - `NUVION_MODEL_GCS_POINTER_URI`: GCS pointer JSON URI (default: `gs://nuv-model/pointers/anomalyclip/prod.json`)
 - `NUVION_MODEL_PROFILE`: pull-model 프로필 (`runtime|light|full`)
 - `NUVION_MODEL_DIR`: pull-model 기본 저장 루트

--- a/nuvion_app/cli.py
+++ b/nuvion_app/cli.py
@@ -6,11 +6,16 @@ import sys
 
 from nuvion_app.config import DEFAULT_PORT, load_env, resolve_config_path, setup_config
 from nuvion_app.model_store import (
+    DEFAULT_MODEL_POINTER,
+    DEFAULT_MODEL_PRESIGN_TTL_SECONDS,
     DEFAULT_MODEL_GCS_POINTER_URI,
+    DEFAULT_MODEL_SERVER_BASE_URL,
+    DEFAULT_MODEL_SOURCE,
     DEFAULT_MODEL_PROFILE,
     anomalyclip_text_features_path,
     anomalyclip_triton_repository_path,
     pull_model_from_gcs,
+    pull_model_from_server,
     resolve_default_model_dir,
 )
 
@@ -34,12 +39,50 @@ def _build_parser() -> argparse.ArgumentParser:
 
     pull_parser = subparsers.add_parser(
         "pull-model",
-        help="Download model artifacts from GCS pointer for Triton/AnomalyCLIP runtime",
+        help="Download model artifacts for Triton/AnomalyCLIP runtime (source=gcs|server)",
+    )
+    pull_parser.add_argument("--config", help="Path to config env file")
+    pull_parser.add_argument(
+        "--source",
+        choices=("gcs", "server"),
+        default=os.getenv("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE),
+        help="Model artifact source",
     )
     pull_parser.add_argument(
         "--gcs-pointer-uri",
         default=os.getenv("NUVION_MODEL_GCS_POINTER_URI", DEFAULT_MODEL_GCS_POINTER_URI),
-        help="GCS pointer JSON URI",
+        help="GCS pointer JSON URI (used when --source gcs)",
+    )
+    pull_parser.add_argument(
+        "--pointer",
+        default=os.getenv("NUVION_MODEL_POINTER", DEFAULT_MODEL_POINTER),
+        help="Pointer identifier (used when --source server), e.g. anomalyclip/prod",
+    )
+    pull_parser.add_argument(
+        "--server-base-url",
+        default=os.getenv("NUVION_MODEL_SERVER_BASE_URL", os.getenv("NUVION_SERVER_BASE_URL", DEFAULT_MODEL_SERVER_BASE_URL)),
+        help="NUV-BE base URL for model presign API (used when --source server)",
+    )
+    pull_parser.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=int(os.getenv("NUVION_MODEL_PRESIGN_TTL_SECONDS", str(DEFAULT_MODEL_PRESIGN_TTL_SECONDS))),
+        help="Requested signed URL TTL seconds (used when --source server)",
+    )
+    pull_parser.add_argument(
+        "--access-token",
+        default=os.getenv("NUVION_MODEL_SERVER_ACCESS_TOKEN", ""),
+        help="Optional bearer token for presign API (used when --source server)",
+    )
+    pull_parser.add_argument(
+        "--username",
+        default=os.getenv("NUVION_DEVICE_USERNAME", ""),
+        help="Device username for /auth/login fallback (used when --source server and no token)",
+    )
+    pull_parser.add_argument(
+        "--password",
+        default=os.getenv("NUVION_DEVICE_PASSWORD", ""),
+        help="Device password for /auth/login fallback (used when --source server and no token)",
     )
     pull_parser.add_argument(
         "--local-dir",
@@ -63,6 +106,13 @@ def main() -> None:
     if sys.version_info < (3, 10):
         sys.stderr.write("Python 3.10+ is required.\n")
         sys.exit(2)
+
+    # Load default env early so parser defaults can resolve from config file.
+    try:
+        load_env()
+    except Exception:
+        pass
+
     parser = _build_parser()
     args = parser.parse_args()
 
@@ -97,14 +147,35 @@ def main() -> None:
         return
 
     if args.command == "pull-model":
+        load_env(args.config)
         try:
-            pointer_uri = args.gcs_pointer_uri.strip() or DEFAULT_MODEL_GCS_POINTER_URI
-            local_dir = args.local_dir.strip() or str(resolve_default_model_dir(pointer_uri))
-            model_dir, _ = pull_model_from_gcs(
-                pointer_uri=pointer_uri,
-                local_dir=local_dir,
-                profile=args.profile,
-            )
+            source = (args.source or DEFAULT_MODEL_SOURCE).strip().lower()
+            if source == "server":
+                pointer = (args.pointer or DEFAULT_MODEL_POINTER).strip()
+                local_dir = args.local_dir.strip() or str(resolve_default_model_dir(f"server:{pointer}:{args.profile}"))
+                server_base_url = (args.server_base_url or os.getenv("NUVION_SERVER_BASE_URL", "")).strip()
+                access_token = (args.access_token or "").strip() or None
+                username = (args.username or "").strip() or None
+                password = (args.password or "").strip() or None
+
+                model_dir, _ = pull_model_from_server(
+                    server_base_url=server_base_url,
+                    pointer=pointer,
+                    profile=args.profile,
+                    local_dir=local_dir,
+                    ttl_seconds=args.ttl_seconds,
+                    access_token=access_token,
+                    username=username,
+                    password=password,
+                )
+            else:
+                pointer_uri = args.gcs_pointer_uri.strip() or DEFAULT_MODEL_GCS_POINTER_URI
+                local_dir = args.local_dir.strip() or str(resolve_default_model_dir(pointer_uri))
+                model_dir, _ = pull_model_from_gcs(
+                    pointer_uri=pointer_uri,
+                    local_dir=local_dir,
+                    profile=args.profile,
+                )
         except Exception as exc:
             sys.stderr.write(f"Failed to pull model artifacts: {exc}\n")
             sys.exit(1)
@@ -113,7 +184,7 @@ def main() -> None:
         triton_repo = anomalyclip_triton_repository_path(model_dir)
 
         sys.stdout.write(f"Model artifacts downloaded to: {model_dir}\n")
-        sys.stdout.write("Source: gcs\n")
+        sys.stdout.write(f"Source: {args.source}\n")
         if text_features.exists():
             sys.stdout.write("Suggested env for AnomalyCLIP Triton backend:\n")
             sys.stdout.write("  NUVION_ZSAD_BACKEND=triton\n")

--- a/nuvion_app/config_template.env
+++ b/nuvion_app/config_template.env
@@ -39,6 +39,13 @@ NUVION_ZERO_SHOT_SAMPLE_SEC=2
 NUVION_ZSAD_BACKEND=triton
 
 # Model bundle (for `nuv-agent pull-model`)
+# source: server (recommended) | gcs (fallback)
+NUVION_MODEL_SOURCE=server
+NUVION_MODEL_POINTER=anomalyclip/prod
+NUVION_MODEL_PRESIGN_TTL_SECONDS=300
+NUVION_MODEL_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io
+# Optional: pre-issued bearer token for server source
+# NUVION_MODEL_SERVER_ACCESS_TOKEN=
 NUVION_MODEL_GCS_POINTER_URI=gs://nuv-model/pointers/anomalyclip/prod.json
 NUVION_MODEL_PROFILE=runtime
 NUVION_MODEL_DIR=~/.cache/nuvion/models

--- a/nuvion_app/model_store.py
+++ b/nuvion_app/model_store.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
-from pathlib import Path
-from typing import Optional
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path, PurePosixPath
+from typing import Any, Optional
 
+DEFAULT_MODEL_SOURCE = "gcs"
 DEFAULT_MODEL_PROFILE = "runtime"
+DEFAULT_MODEL_POINTER = "anomalyclip/prod"
+DEFAULT_MODEL_PRESIGN_TTL_SECONDS = 300
+DEFAULT_MODEL_SERVER_BASE_URL = "https://api.nuvion-dev.plaidai.io"
 DEFAULT_MODEL_GCS_POINTER_URI = "gs://nuv-model/pointers/anomalyclip/prod.json"
 
-
-_GCS_PROFILE_KEYS: dict[str, list[str]] = {
+_PROFILE_KEYS: dict[str, list[str]] = {
     "runtime": ["text_features", "plan", "triton_config", "manifest"],
     "light": ["text_features", "manifest"],
     "full": [
@@ -50,7 +57,7 @@ def _resolve_local_dir(identifier: str, local_dir: Optional[str]) -> Path:
 
 
 def _ensure_profile(profile: str) -> None:
-    valid = set(_GCS_PROFILE_KEYS.keys())
+    valid = set(_PROFILE_KEYS.keys())
     if profile not in valid:
         allowed = ", ".join(sorted(valid))
         raise ValueError(f"Unsupported profile '{profile}'. Expected one of: {allowed}")
@@ -86,7 +93,7 @@ def _gcs_uri(bucket: str, object_path: str) -> str:
     return f"gs://{bucket}/{object_path}"
 
 
-def _gcs_cat_json(uri: str) -> dict:
+def _gcs_cat_json(uri: str) -> dict[str, Any]:
     result = _run_command(["gcloud", "storage", "cat", uri], capture_output=True)
     try:
         return json.loads(result.stdout)
@@ -99,11 +106,180 @@ def _copy_gcs_object(src_uri: str, dst_path: Path) -> None:
     _run_command(["gcloud", "storage", "cp", src_uri, str(dst_path)])
 
 
+def _sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _normalize_base_url(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _http_json(
+    method: str,
+    url: str,
+    payload: Optional[dict[str, Any]] = None,
+    headers: Optional[dict[str, str]] = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    if headers:
+        for key, value in headers.items():
+            req.add_header(key, value)
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            if not body:
+                return {}
+            return json.loads(body)
+    except urllib.error.HTTPError as exc:
+        body = ""
+        try:
+            body = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            pass
+        raise RuntimeError(f"HTTP {exc.code} {exc.reason}: {body}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"URL error: {exc.reason}") from exc
+
+
+def _extract_api_data(payload: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(payload.get("data"), dict):
+        return payload["data"]
+    return payload
+
+
+def _login_for_access_token(server_base_url: str, username: str, password: str) -> str:
+    if not username or not password:
+        raise RuntimeError(
+            "Access token is missing. Provide --access-token or set device credentials "
+            "(NUVION_DEVICE_USERNAME/NUVION_DEVICE_PASSWORD)."
+        )
+
+    login_url = f"{_normalize_base_url(server_base_url)}/auth/login"
+    response = _http_json("POST", login_url, payload={"username": username, "password": password})
+    data = _extract_api_data(response)
+    token = data.get("accessToken")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login succeeded but accessToken is missing in response.")
+    return token.strip()
+
+
+def _resolve_profile_keys(pointer: dict[str, Any], profile: str) -> list[str]:
+    profiles = pointer.get("profiles")
+    if isinstance(profiles, dict):
+        candidate = profiles.get(profile)
+        if isinstance(candidate, list):
+            keys = [str(item).strip() for item in candidate if str(item).strip()]
+            if keys:
+                return keys
+    return list(_PROFILE_KEYS[profile])
+
+
+def _resolve_local_rel_path(key: str, path_hint: Optional[str] = None) -> str:
+    preset = _DEFAULT_LOCAL_PATHS.get(key)
+    if preset:
+        return preset
+
+    if path_hint:
+        filename = PurePosixPath(path_hint).name
+        if filename:
+            return f"extras/{key}/{filename}"
+
+    return f"extras/{key}"
+
+
+def _artifact_path_from_pointer(artifact: Any, key: str) -> tuple[str, Optional[str], Optional[int]]:
+    if isinstance(artifact, str):
+        path = artifact.strip()
+        if not path:
+            raise RuntimeError(f"Artifact '{key}' path is empty")
+        return path, None, None
+
+    if isinstance(artifact, dict):
+        path = str(artifact.get("path") or "").strip()
+        if not path:
+            raise RuntimeError(f"Artifact '{key}' path is empty")
+        sha256 = artifact.get("sha256")
+        size_bytes = artifact.get("sizeBytes")
+        normalized_sha = str(sha256).strip() if sha256 is not None else None
+        normalized_size = size_bytes if isinstance(size_bytes, int) else None
+        return path, normalized_sha, normalized_size
+
+    raise RuntimeError(f"Artifact '{key}' format is invalid")
+
+
+def _validate_download_integrity(path: Path, expected_sha256: Optional[str], expected_size_bytes: Optional[int], key: str) -> None:
+    if expected_size_bytes is not None:
+        actual_size = path.stat().st_size
+        if actual_size != expected_size_bytes:
+            raise RuntimeError(
+                f"Artifact size mismatch for '{key}'. expected={expected_size_bytes} actual={actual_size}"
+            )
+
+    if expected_sha256:
+        actual_sha256 = _sha256_file(path)
+        if actual_sha256.lower() != expected_sha256.lower():
+            raise RuntimeError(
+                f"Artifact sha256 mismatch for '{key}'. expected={expected_sha256} actual={actual_sha256}"
+            )
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _download_http_file(url: str, dst_path: Path, timeout: int = 120, max_retries: int = 3) -> None:
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    part_path = dst_path.with_suffix(dst_path.suffix + ".part")
+
+    last_error: Optional[Exception] = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=timeout) as response:
+                status = response.getcode()
+                if status < 200 or status >= 300:
+                    raise RuntimeError(f"HTTP status={status}")
+                with part_path.open("wb") as out:
+                    while True:
+                        chunk = response.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        out.write(chunk)
+            part_path.replace(dst_path)
+            return
+        except Exception as exc:
+            last_error = exc
+            if part_path.exists():
+                try:
+                    part_path.unlink()
+                except OSError:
+                    pass
+            if attempt < max_retries:
+                time.sleep(min(0.5 * (2 ** (attempt - 1)), 4.0))
+
+    raise RuntimeError(f"Download failed after {max_retries} attempts: {url} ({last_error})")
+
+
 def pull_model_from_gcs(
     pointer_uri: str,
     local_dir: Optional[str] = None,
     profile: str = DEFAULT_MODEL_PROFILE,
-) -> tuple[Path, dict]:
+) -> tuple[Path, dict[str, Any]]:
     _ensure_profile(profile)
 
     bucket, _ = _parse_gs_uri(pointer_uri)
@@ -114,7 +290,7 @@ def pull_model_from_gcs(
         raise RuntimeError("Pointer JSON must include 'artifacts' object")
 
     runtime_layout = pointer.get("runtime_layout")
-    local_paths = {}
+    local_paths: dict[str, str] = {}
     if isinstance(runtime_layout, dict):
         lp = runtime_layout.get("local_paths")
         if isinstance(lp, dict):
@@ -123,29 +299,141 @@ def pull_model_from_gcs(
     target_dir = _resolve_local_dir(identifier=pointer_uri, local_dir=local_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    required_keys = _GCS_PROFILE_KEYS[profile]
+    required_keys = _resolve_profile_keys(pointer, profile)
     missing = [key for key in required_keys if key not in artifacts]
     if missing:
         raise RuntimeError(f"Pointer is missing required artifacts for profile '{profile}': {', '.join(missing)}")
 
-    downloaded: list[dict[str, str]] = []
+    downloaded: list[dict[str, Any]] = []
     for key in required_keys:
-        src_obj = str(artifacts[key])
+        src_obj, expected_sha256, expected_size = _artifact_path_from_pointer(artifacts[key], key)
         src_uri = _gcs_uri(bucket, src_obj)
-        local_rel = local_paths.get(key, _DEFAULT_LOCAL_PATHS.get(key, f"extras/{key}"))
+        local_rel = local_paths.get(key, _resolve_local_rel_path(key, src_obj))
         dst = (target_dir / local_rel).resolve()
         _copy_gcs_object(src_uri=src_uri, dst_path=dst)
-        downloaded.append({"key": key, "src": src_uri, "dst": str(dst)})
+        _validate_download_integrity(dst, expected_sha256, expected_size, key)
+        downloaded.append({
+            "key": key,
+            "src": src_uri,
+            "dst": str(dst),
+            "sha256": expected_sha256,
+            "sizeBytes": expected_size,
+        })
 
     metadata_dir = (target_dir / "metadata").resolve()
     metadata_dir.mkdir(parents=True, exist_ok=True)
-    pointer_out = metadata_dir / "gcs_pointer.json"
-    pointer_out.write_text(json.dumps(pointer, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-
-    downloaded_index = metadata_dir / "downloaded_from_gcs.json"
-    downloaded_index.write_text(json.dumps(downloaded, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    _write_json(metadata_dir / "gcs_pointer.json", pointer)
+    _write_json(metadata_dir / "downloaded_from_gcs.json", downloaded)
 
     return target_dir, pointer
+
+
+def pull_model_from_server(
+    server_base_url: str,
+    pointer: str = DEFAULT_MODEL_POINTER,
+    profile: str = DEFAULT_MODEL_PROFILE,
+    local_dir: Optional[str] = None,
+    ttl_seconds: int = DEFAULT_MODEL_PRESIGN_TTL_SECONDS,
+    access_token: Optional[str] = None,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> tuple[Path, dict[str, Any]]:
+    _ensure_profile(profile)
+
+    normalized_pointer = pointer.strip()
+    if not normalized_pointer:
+        raise ValueError("pointer is required for source=server")
+    if ttl_seconds <= 0:
+        raise ValueError("ttl_seconds must be positive")
+
+    base_url = _normalize_base_url(server_base_url.strip())
+    if not base_url:
+        raise ValueError("server_base_url is required for source=server")
+
+    token = (access_token or "").strip()
+    if not token:
+        token = _login_for_access_token(
+            server_base_url=base_url,
+            username=(username or "").strip(),
+            password=(password or "").strip(),
+        )
+
+    request_payload = {
+        "pointer": normalized_pointer,
+        "profile": profile,
+        "ttlSeconds": int(ttl_seconds),
+    }
+    headers = {"Authorization": f"Bearer {token}"}
+    response_payload = _http_json(
+        "POST",
+        f"{base_url}/devices/models/presign",
+        payload=request_payload,
+        headers=headers,
+    )
+    data = _extract_api_data(response_payload)
+
+    artifacts = data.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise RuntimeError("Server response must include artifacts array")
+
+    artifact_by_key: dict[str, dict[str, Any]] = {}
+    for item in artifacts:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("key") or "").strip()
+        if key:
+            artifact_by_key[key] = item
+
+    required_keys = _PROFILE_KEYS[profile]
+    missing = [key for key in required_keys if key not in artifact_by_key]
+    if missing:
+        raise RuntimeError(f"Presign response is missing required artifacts for profile '{profile}': {', '.join(missing)}")
+
+    identifier = f"server:{normalized_pointer}:{profile}"
+    target_dir = _resolve_local_dir(identifier=identifier, local_dir=local_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    downloaded: list[dict[str, Any]] = []
+    for key in required_keys:
+        artifact = artifact_by_key[key]
+        url = str(artifact.get("url") or "").strip()
+        if not url:
+            raise RuntimeError(f"Presign artifact '{key}' is missing url")
+
+        path_hint = str(artifact.get("path") or "").strip() or None
+        expected_sha256 = str(artifact.get("sha256") or "").strip()
+        if not expected_sha256:
+            raise RuntimeError(f"Presign artifact '{key}' is missing sha256")
+
+        expected_size: Optional[int] = None
+        size_bytes = artifact.get("sizeBytes")
+        if isinstance(size_bytes, int):
+            expected_size = size_bytes
+
+        local_rel = _resolve_local_rel_path(key, path_hint)
+        dst = (target_dir / local_rel).resolve()
+
+        _download_http_file(url=url, dst_path=dst)
+        _validate_download_integrity(dst, expected_sha256, expected_size, key)
+
+        downloaded.append(
+            {
+                "key": key,
+                "url": url,
+                "dst": str(dst),
+                "path": path_hint,
+                "sha256": expected_sha256,
+                "sizeBytes": expected_size,
+                "expiresAt": artifact.get("expiresAt"),
+            }
+        )
+
+    metadata_dir = (target_dir / "metadata").resolve()
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(metadata_dir / "server_presign_response.json", data)
+    _write_json(metadata_dir / "downloaded_from_server.json", downloaded)
+
+    return target_dir, data
 
 
 def anomalyclip_text_features_path(model_dir: Path) -> Path:


### PR DESCRIPTION
## NUV-222: server presign source 구현

### 변경 사항
- `nuv-agent pull-model`에 `--source server` 추가 (기존 `gcs` 하위호환 유지)
- `NUV-BE /devices/models/presign` 연동 경로 추가
  - `--access-token` 직접 사용 가능
  - 토큰 미지정 시 `NUVION_DEVICE_USERNAME/NUVION_DEVICE_PASSWORD`로 `/auth/login` 후 presign 호출
- signed URL 다운로드 구현
  - 임시 파일(`.part`)로 저장 후 완료 시 rename
  - 재시도(backoff) 적용
- 무결성 검증 강화
  - `sha256` 필수 검증
  - `sizeBytes` 존재 시 크기 검증
- 다운로드 결과 메타데이터 저장
  - `metadata/server_presign_response.json`
  - `metadata/downloaded_from_server.json`
- 환경변수/문서 갱신
  - `NUVION_MODEL_SOURCE`, `NUVION_MODEL_POINTER`, `NUVION_MODEL_PRESIGN_TTL_SECONDS`, `NUVION_MODEL_SERVER_BASE_URL`, `NUVION_MODEL_SERVER_ACCESS_TOKEN`

### 검증
- `python3 -m py_compile nuvion_app/model_store.py nuvion_app/cli.py`
- `python3 -m nuvion_app.cli pull-model --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 서버 기반 presign 워크플로우를 통한 모델 번들 가져오기 기능 추가
  * GCS 기반 가져오기를 대체 경로로 지원
  * 모델 아티팩트 구성을 위한 새로운 CLI 옵션 추가 (--model-source, --model-pointer, --server-base-url 등)
  * 다운로드 무결성 검증 기능 (SHA-256, 크기 확인) 추가

* **Documentation**
  * 서버 기반 및 GCS 기반 모델 가져오기 워크플로우 문서화
  * 새로운 환경 변수 (NUVION_MODEL_SOURCE, NUVION_MODEL_POINTER, NUVION_MODEL_PRESIGN_TTL_SECONDS 등) 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->