### PR TITLE
fix: bootstrap 진행상태 로그를 stderr로 노출

### DIFF
--- a/nuvion_app/runtime/bootstrap.py
+++ b/nuvion_app/runtime/bootstrap.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import time
 
 from nuvion_app.runtime.errors import BootstrapError
@@ -17,6 +18,12 @@ def _truthy(value: str | None, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
+def _emit_progress(message: str) -> None:
+    # Bootstrap runs before pipeline logging is initialized, so print directly.
+    sys.stderr.write(f"[BOOTSTRAP] {message}\n")
+    sys.stderr.flush()
+
+
 def ensure_ready(stage: str = "run") -> bool:
     if not _truthy(os.getenv("NUVION_RUNTIME_BOOTSTRAP_ENABLED"), default=True):
         return True
@@ -27,11 +34,15 @@ def ensure_ready(stage: str = "run") -> bool:
 
     max_retries = int(os.getenv("NUVION_BOOTSTRAP_MAX_RETRIES", "3"))
     base_backoff = float(os.getenv("NUVION_BOOTSTRAP_BACKOFF_SEC", "2"))
+    _emit_progress(f"stage={stage} 시작: 모델/Triton 준비를 점검합니다.")
 
     for attempt in range(1, max_retries + 1):
         try:
+            _emit_progress(f"stage={stage} attempt={attempt}/{max_retries} 모델 점검 중...")
             model_dir = ensure_model_ready(stage=stage)
+            _emit_progress(f"stage={stage} attempt={attempt}/{max_retries} Triton 점검 중...")
             ensure_triton_ready(stage=stage, model_dir=model_dir)
+            _emit_progress(f"stage={stage} 완료: runtime 준비 완료")
             return True
         except BootstrapError as exc:
             log.warning(
@@ -43,10 +54,16 @@ def ensure_ready(stage: str = "run") -> bool:
                 exc.retryable,
                 str(exc),
             )
+            _emit_progress(
+                f"stage={stage} attempt={attempt}/{max_retries} 실패: "
+                f"code={exc.code} retryable={exc.retryable} message={exc}"
+            )
             if not exc.retryable or attempt >= max_retries:
                 os.environ["NUVION_ZSAD_BACKEND"] = "none"
+                _emit_progress("최종 실패: 추론 backend를 none으로 강등하고 서비스는 계속 유지합니다.")
                 return False
             sleep_sec = min(base_backoff * (2 ** (attempt - 1)), 30.0)
+            _emit_progress(f"{sleep_sec:.1f}s 후 재시도합니다.")
             time.sleep(sleep_sec)
         except Exception as exc:  # pragma: no cover
             log.warning(
@@ -56,11 +73,18 @@ def ensure_ready(stage: str = "run") -> bool:
                 max_retries,
                 str(exc),
             )
+            _emit_progress(
+                f"stage={stage} attempt={attempt}/{max_retries} 실패: "
+                f"code=runtime_bootstrap_failed message={exc}"
+            )
             if attempt >= max_retries:
                 os.environ["NUVION_ZSAD_BACKEND"] = "none"
+                _emit_progress("최종 실패: 추론 backend를 none으로 강등하고 서비스는 계속 유지합니다.")
                 return False
             sleep_sec = min(base_backoff * (2 ** (attempt - 1)), 30.0)
+            _emit_progress(f"{sleep_sec:.1f}s 후 재시도합니다.")
             time.sleep(sleep_sec)
 
     os.environ["NUVION_ZSAD_BACKEND"] = "none"
+    _emit_progress("최종 실패: 추론 backend를 none으로 강등하고 서비스는 계속 유지합니다.")
     return False

--- a/nuvion_app/runtime/docker_manager.py
+++ b/nuvion_app/runtime/docker_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from typing import Tuple
 from urllib.parse import urlparse
 
@@ -22,6 +23,11 @@ def _truthy(value: str | None, default: bool = False) -> bool:
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _emit_progress(message: str) -> None:
+    sys.stderr.write(f"[BOOTSTRAP] {message}\n")
+    sys.stderr.flush()
 
 
 def parse_triton_host_port(url: str) -> Tuple[str, int]:
@@ -85,12 +91,14 @@ def _ensure_colima_running() -> None:
 
     status = run_command(["colima", "status"], check=False, capture_output=True)
     if status.returncode == 0:
+        _emit_progress("Colima가 이미 실행 중입니다.")
         return
 
     if not _truthy(os.getenv("NUVION_DOCKER_AUTOSTART"), default=True):
         raise BootstrapError("docker_daemon_unavailable", "Docker daemon is down and autostart is disabled.", retryable=False)
 
     log.info("[BOOTSTRAP] Docker daemon unavailable. Starting Colima fallback.")
+    _emit_progress("Docker daemon이 없어 Colima fallback을 시작합니다.")
     run_command(["colima", "start", "--cpu", "4", "--memory", "8", "--disk", "40"], check=True)
 
 
@@ -110,16 +118,20 @@ def ensure_docker_ready(triton_url: str) -> None:
         _ensure_docker_cli_linux()
 
     if docker_info_ok():
+        _emit_progress("Docker daemon 준비 완료(기존 daemon 사용).")
         return
 
     if os.uname().sysname.lower() == "darwin":
+        _emit_progress("Docker daemon이 없어 Colima 기동을 시도합니다.")
         _ensure_colima_running()
     else:
+        _emit_progress("Linux Docker daemon 기동을 시도합니다.")
         _start_docker_daemon_linux()
         ensure_nvidia_container_toolkit()
 
     if not docker_info_ok():
         raise BootstrapError("docker_daemon_unavailable", "Docker daemon is not available.")
+    _emit_progress("Docker daemon 준비 완료.")
 
 
 def container_exists(name: str) -> bool:

--- a/nuvion_app/runtime/model_guard.py
+++ b/nuvion_app/runtime/model_guard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from pathlib import Path
 
 from nuvion_app.model_store import (
@@ -29,6 +30,11 @@ def _truthy(value: str | None, default: bool = False) -> bool:
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _emit_progress(message: str) -> None:
+    sys.stderr.write(f"[BOOTSTRAP] {message}\n")
+    sys.stderr.flush()
 
 
 def _is_darwin() -> bool:
@@ -110,6 +116,7 @@ def ensure_model_ready(stage: str) -> Path:
     model_dir = resolve_model_dir(profile)
     missing_before = _missing_required_files(model_dir, profile)
     if not missing_before:
+        _emit_progress(f"모델 파일 점검 완료: 누락 없음 ({model_dir})")
         return model_dir
 
     try:
@@ -119,7 +126,13 @@ def ensure_model_ready(stage: str) -> Path:
             os.getenv("NUVION_MODEL_PROFILE", DEFAULT_MODEL_PROFILE),
             os.getenv("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE),
         )
+        _emit_progress(
+            f"모델 파일 누락 감지({len(missing_before)}개). "
+            f"자동 다운로드 시작: source={os.getenv('NUVION_MODEL_SOURCE', DEFAULT_MODEL_SOURCE)} "
+            f"profile={profile}"
+        )
         _pull_model(profile=profile, model_dir=model_dir)
+        _emit_progress("모델 다운로드 완료. 무결성 점검 중...")
     except Exception as exc:
         raise BootstrapError("model_pull_failed", f"Failed to pull model artifacts: {exc}") from exc
 
@@ -129,5 +142,6 @@ def ensure_model_ready(stage: str) -> Path:
             "model_pull_failed",
             f"Model pull finished but required files are still missing: {', '.join(missing_after)}",
         )
+    _emit_progress(f"모델 파일 점검 완료: 준비됨 ({model_dir})")
 
     return model_dir

--- a/nuvion_app/runtime/platform_installer.py
+++ b/nuvion_app/runtime/platform_installer.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -18,6 +19,11 @@ def _truthy(value: str | None, default: bool = False) -> bool:
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _emit_progress(message: str) -> None:
+    sys.stderr.write(f"[BOOTSTRAP] {message}\n")
+    sys.stderr.flush()
 
 
 def command_exists(command: str) -> bool:
@@ -70,6 +76,7 @@ def ensure_homebrew_installed() -> str:
         raise BootstrapError("brew_install_failed", "Homebrew is not installed.", retryable=False)
 
     log.info("[BOOTSTRAP] Homebrew missing. Installing Homebrew in non-interactive mode.")
+    _emit_progress("Homebrew가 없어 자동 설치를 시작합니다.")
     try:
         run_command(
             [
@@ -79,7 +86,7 @@ def ensure_homebrew_installed() -> str:
             ],
             env={"NONINTERACTIVE": "1"},
             check=True,
-            capture_output=True,
+            capture_output=False,
         )
     except Exception as exc:
         raise BootstrapError("brew_install_failed", f"Failed to install Homebrew: {exc}") from exc
@@ -101,10 +108,12 @@ def brew_install(packages: Iterable[str]) -> None:
     for package in package_list:
         check_result = run_command([brew_path, "list", package], check=False)
         if check_result.returncode == 0:
+            _emit_progress(f"brew 패키지 이미 설치됨: {package}")
             continue
 
         try:
             log.info("[BOOTSTRAP] Installing package via brew: %s", package)
+            _emit_progress(f"brew install 진행 중: {package}")
             run_command([brew_path, "install", package], check=True)
         except Exception as exc:
             raise BootstrapError("docker_install_failed", f"brew install {package} failed: {exc}") from exc
@@ -116,7 +125,9 @@ def apt_install(packages: Iterable[str]) -> None:
         return
 
     try:
+        _emit_progress("apt update 진행 중...")
         run_command(["apt-get", "update"], as_root=True)
+        _emit_progress(f"apt install 진행 중: {' '.join(package_list)}")
         run_command(["apt-get", "install", "-y", *package_list], as_root=True)
     except Exception as exc:
         raise BootstrapError("docker_install_failed", f"apt install failed: {exc}") from exc

--- a/nuvion_app/runtime/triton_manager.py
+++ b/nuvion_app/runtime/triton_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -57,6 +58,11 @@ def _truthy(value: str | None, default: bool = False) -> bool:
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _emit_progress(message: str) -> None:
+    sys.stderr.write(f"[BOOTSTRAP] {message}\n")
+    sys.stderr.flush()
 
 
 def _health_ready(host: str, port: int, timeout_sec: int) -> bool:
@@ -134,8 +140,10 @@ def ensure_triton_ready(stage: str, model_dir: Path) -> None:
         return
 
     if _health_ready(host, port, timeout_sec=3):
+        _emit_progress(f"Triton 이미 준비됨: {host}:{port}")
         return
 
+    _emit_progress("Triton이 준비되지 않아 Docker/Triton 자동 복구를 시작합니다.")
     ensure_docker_ready(triton_url)
 
     repository = resolve_repository_for_runtime(model_dir).resolve()
@@ -143,16 +151,20 @@ def ensure_triton_ready(stage: str, model_dir: Path) -> None:
     image = os.getenv("NUVION_TRITON_IMAGE", "nvcr.io/nvidia/tritonserver:24.10-py3").strip() or "nvcr.io/nvidia/tritonserver:24.10-py3"
 
     if container_exists(container_name):
+        _emit_progress(f"기존 Triton 컨테이너 확인: {container_name}")
         if container_running(container_name):
             if _health_ready(host, port, timeout_sec=5):
+                _emit_progress("기존 Triton 컨테이너 재사용 성공")
                 return
             remove_container(container_name)
         else:
             start_container(container_name)
             if _health_ready(host, port, timeout_sec=10):
+                _emit_progress("중지된 Triton 컨테이너 재기동 성공")
                 return
             remove_container(container_name)
 
+    _emit_progress(f"Triton 컨테이너 생성 중: {container_name}")
     run_triton_container(
         name=container_name,
         image=image,
@@ -168,3 +180,4 @@ def ensure_triton_ready(stage: str, model_dir: Path) -> None:
         )
 
     log.info("[BOOTSTRAP] Triton is ready (stage=%s, url=%s)", stage, triton_url)
+    _emit_progress(f"Triton 준비 완료: {host}:{port}")


### PR DESCRIPTION
## 변경 내용\n- bootstrap 초기화 단계에서 진행상태를 stderr로 즉시 출력\n- 모델 점검/다운로드, Docker 점검/기동, Triton 준비 단계를 실시간 노출\n- Homebrew 자동설치는 출력 숨김 해제(capture_output=false)로 설치 진행상태 노출\n\n## 효과\n- \ 첫 실행 시 무응답처럼 보이던 구간을 단계별 메시지로 확인 가능\n\n## 테스트\n- python3 -m unittest discover -s tests -p 'test_*.py'\n- python3 -m compileall nuvion_app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항
* Bootstrap 초기화 과정에서 Docker 데몬, 모델 다운로드, 플랫폼 설치, Triton 컨테이너 등 주요 단계의 진행 상황 메시지 추가
* 한국어로 제공되는 단계별 진행 정보로 초기화 과정의 투명성 및 사용자 경험 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->