### PR TITLE
fix(model): signed URL 실패 시 presign 재발급 자동 복구

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ nuv-agent pull-model \
 
 - `--access-token`을 직접 전달하거나, 생략 시 `NUVION_DEVICE_USERNAME/NUVION_DEVICE_PASSWORD`로 `/auth/login` 후 presign 호출
 - 다운로드 후 각 artifact에 대해 `sha256` 무결성 검증 수행
+- signed URL 다운로드 중 400/401/403 오류가 발생하면, presign URL을 자동 재발급 받아 이어서 재시도
 - 결과 메타데이터: `metadata/downloaded_from_server.json`
 
 ## Pull model bundle (GCS fallback)

--- a/nuvion_app/model_store.py
+++ b/nuvion_app/model_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import subprocess
 import time
@@ -16,6 +17,9 @@ DEFAULT_MODEL_POINTER = "anomalyclip/prod"
 DEFAULT_MODEL_PRESIGN_TTL_SECONDS = 300
 DEFAULT_MODEL_SERVER_BASE_URL = "https://api.nuvion-dev.plaidai.io"
 DEFAULT_MODEL_GCS_POINTER_URI = "gs://nuv-model/pointers/anomalyclip/prod.json"
+DEFAULT_MODEL_PRESIGN_REFRESH_RETRIES = 2
+
+log = logging.getLogger(__name__)
 
 _PROFILE_KEYS: dict[str, list[str]] = {
     "runtime": ["text_features", "plan", "triton_config", "manifest"],
@@ -159,6 +163,87 @@ def _extract_api_data(payload: dict[str, Any]) -> dict[str, Any]:
     if isinstance(payload.get("data"), dict):
         return payload["data"]
     return payload
+
+
+def _fetch_server_presign(
+    *,
+    base_url: str,
+    token: str,
+    pointer: str,
+    profile: str,
+    ttl_seconds: int,
+) -> dict[str, Any]:
+    request_payload = {
+        "pointer": pointer,
+        "profile": profile,
+        "ttlSeconds": int(ttl_seconds),
+    }
+    headers = {"Authorization": f"Bearer {token}"}
+    response_payload = _http_json(
+        "POST",
+        f"{base_url}/devices/models/presign",
+        payload=request_payload,
+        headers=headers,
+    )
+    return _extract_api_data(response_payload)
+
+
+def _build_artifact_map(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    artifacts = data.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise RuntimeError("Server response must include artifacts array")
+
+    artifact_by_key: dict[str, dict[str, Any]] = {}
+    for item in artifacts:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("key") or "").strip()
+        if key:
+            artifact_by_key[key] = item
+    return artifact_by_key
+
+
+def _ensure_required_artifacts(
+    *,
+    artifact_by_key: dict[str, dict[str, Any]],
+    profile: str,
+) -> list[str]:
+    required_keys = _PROFILE_KEYS[profile]
+    missing = [key for key in required_keys if key not in artifact_by_key]
+    if missing:
+        raise RuntimeError(
+            f"Presign response is missing required artifacts for profile '{profile}': {', '.join(missing)}"
+        )
+    return required_keys
+
+
+def _is_integrity_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "sha256 mismatch" in message or "size mismatch" in message
+
+
+def _is_signed_url_refresh_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    tokens = (
+        "http error 400",
+        "http error 401",
+        "http error 403",
+        "signature",
+        "x-goog",
+        "request has expired",
+        "expired",
+    )
+    return any(token in message for token in tokens)
+
+
+def _cleanup_download_target(path: Path) -> None:
+    part_path = path.with_suffix(path.suffix + ".part")
+    for candidate in (path, part_path):
+        try:
+            if candidate.exists():
+                candidate.unlink()
+        except OSError:
+            pass
 
 
 def _login_for_access_token(server_base_url: str, username: str, password: str) -> str:
@@ -358,75 +443,114 @@ def pull_model_from_server(
             password=(password or "").strip(),
         )
 
-    request_payload = {
-        "pointer": normalized_pointer,
-        "profile": profile,
-        "ttlSeconds": int(ttl_seconds),
-    }
-    headers = {"Authorization": f"Bearer {token}"}
-    response_payload = _http_json(
-        "POST",
-        f"{base_url}/devices/models/presign",
-        payload=request_payload,
-        headers=headers,
+    data = _fetch_server_presign(
+        base_url=base_url,
+        token=token,
+        pointer=normalized_pointer,
+        profile=profile,
+        ttl_seconds=ttl_seconds,
     )
-    data = _extract_api_data(response_payload)
-
-    artifacts = data.get("artifacts")
-    if not isinstance(artifacts, list):
-        raise RuntimeError("Server response must include artifacts array")
-
-    artifact_by_key: dict[str, dict[str, Any]] = {}
-    for item in artifacts:
-        if not isinstance(item, dict):
-            continue
-        key = str(item.get("key") or "").strip()
-        if key:
-            artifact_by_key[key] = item
-
-    required_keys = _PROFILE_KEYS[profile]
-    missing = [key for key in required_keys if key not in artifact_by_key]
-    if missing:
-        raise RuntimeError(f"Presign response is missing required artifacts for profile '{profile}': {', '.join(missing)}")
+    artifact_by_key = _build_artifact_map(data)
+    required_keys = _ensure_required_artifacts(artifact_by_key=artifact_by_key, profile=profile)
 
     identifier = f"server:{normalized_pointer}:{profile}"
     target_dir = _resolve_local_dir(identifier=identifier, local_dir=local_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
+    max_refresh_retries = int(
+        os.getenv(
+            "NUVION_MODEL_PRESIGN_REFRESH_RETRIES",
+            str(DEFAULT_MODEL_PRESIGN_REFRESH_RETRIES),
+        )
+    )
+    refresh_attempts = 0
 
     downloaded: list[dict[str, Any]] = []
     for key in required_keys:
-        artifact = artifact_by_key[key]
-        url = str(artifact.get("url") or "").strip()
-        if not url:
-            raise RuntimeError(f"Presign artifact '{key}' is missing url")
+        retried_integrity = False
+        while True:
+            artifact = artifact_by_key[key]
+            url = str(artifact.get("url") or "").strip()
+            if not url:
+                raise RuntimeError(f"Presign artifact '{key}' is missing url")
 
-        path_hint = str(artifact.get("path") or "").strip() or None
-        expected_sha256 = str(artifact.get("sha256") or "").strip()
-        if not expected_sha256:
-            raise RuntimeError(f"Presign artifact '{key}' is missing sha256")
+            path_hint = str(artifact.get("path") or "").strip() or None
+            expected_sha256 = str(artifact.get("sha256") or "").strip()
+            if not expected_sha256:
+                raise RuntimeError(f"Presign artifact '{key}' is missing sha256")
 
-        expected_size: Optional[int] = None
-        size_bytes = artifact.get("sizeBytes")
-        if isinstance(size_bytes, int):
-            expected_size = size_bytes
+            expected_size: Optional[int] = None
+            size_bytes = artifact.get("sizeBytes")
+            if isinstance(size_bytes, int):
+                expected_size = size_bytes
 
-        local_rel = _resolve_local_rel_path(key, path_hint)
-        dst = (target_dir / local_rel).resolve()
+            local_rel = _resolve_local_rel_path(key, path_hint)
+            dst = (target_dir / local_rel).resolve()
 
-        _download_http_file(url=url, dst_path=dst)
-        _validate_download_integrity(dst, expected_sha256, expected_size, key)
+            # Reuse previously downloaded file when it already matches integrity.
+            if dst.exists():
+                try:
+                    _validate_download_integrity(dst, expected_sha256, expected_size, key)
+                    downloaded.append(
+                        {
+                            "key": key,
+                            "url": url,
+                            "dst": str(dst),
+                            "path": path_hint,
+                            "sha256": expected_sha256,
+                            "sizeBytes": expected_size,
+                            "expiresAt": artifact.get("expiresAt"),
+                            "reused": True,
+                        }
+                    )
+                    break
+                except Exception:
+                    _cleanup_download_target(dst)
 
-        downloaded.append(
-            {
-                "key": key,
-                "url": url,
-                "dst": str(dst),
-                "path": path_hint,
-                "sha256": expected_sha256,
-                "sizeBytes": expected_size,
-                "expiresAt": artifact.get("expiresAt"),
-            }
-        )
+            try:
+                _download_http_file(url=url, dst_path=dst)
+                _validate_download_integrity(dst, expected_sha256, expected_size, key)
+                downloaded.append(
+                    {
+                        "key": key,
+                        "url": url,
+                        "dst": str(dst),
+                        "path": path_hint,
+                        "sha256": expected_sha256,
+                        "sizeBytes": expected_size,
+                        "expiresAt": artifact.get("expiresAt"),
+                        "reused": False,
+                    }
+                )
+                break
+            except Exception as exc:
+                _cleanup_download_target(dst)
+
+                if _is_integrity_error(exc) and not retried_integrity:
+                    retried_integrity = True
+                    continue
+
+                if _is_signed_url_refresh_error(exc) and refresh_attempts < max_refresh_retries:
+                    refresh_attempts += 1
+                    log.info(
+                        "[MODEL] refreshing presigned URLs after download failure "
+                        "(attempt=%s/%s, key=%s, error=%s)",
+                        refresh_attempts,
+                        max_refresh_retries,
+                        key,
+                        exc,
+                    )
+                    data = _fetch_server_presign(
+                        base_url=base_url,
+                        token=token,
+                        pointer=normalized_pointer,
+                        profile=profile,
+                        ttl_seconds=ttl_seconds,
+                    )
+                    artifact_by_key = _build_artifact_map(data)
+                    _ensure_required_artifacts(artifact_by_key=artifact_by_key, profile=profile)
+                    continue
+
+                raise
 
     metadata_dir = (target_dir / "metadata").resolve()
     metadata_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/runtime/test_model_store_selfheal.py
+++ b/tests/runtime/test_model_store_selfheal.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from nuvion_app import model_store
+
+
+class ModelStoreSelfHealTest(unittest.TestCase):
+    def test_signed_url_error_detection(self) -> None:
+        self.assertTrue(model_store._is_signed_url_refresh_error(RuntimeError("HTTP Error 400: Bad Request")))
+        self.assertTrue(model_store._is_signed_url_refresh_error(RuntimeError("request has expired")))
+        self.assertFalse(model_store._is_signed_url_refresh_error(RuntimeError("connection reset by peer")))
+
+    def test_pull_model_from_server_refreshes_presign_and_recovers(self) -> None:
+        bad_data = {
+            "data": {
+                "artifacts": [
+                    {
+                        "key": "text_features",
+                        "url": "https://example.com/bad/text_features.npy",
+                        "path": "nuvion/anomalyclip/v0001/source/text_features.npy",
+                        "sha256": "a" * 64,
+                        "sizeBytes": 8,
+                        "expiresAt": "2026-01-01T00:00:00Z",
+                    },
+                    {
+                        "key": "manifest",
+                        "url": "https://example.com/bad/manifest.json",
+                        "path": "nuvion/anomalyclip/v0001/source/gcs_manifest.json",
+                        "sha256": "b" * 64,
+                        "sizeBytes": 8,
+                        "expiresAt": "2026-01-01T00:00:00Z",
+                    },
+                ]
+            }
+        }
+        good_data = {
+            "data": {
+                "artifacts": [
+                    {
+                        "key": "text_features",
+                        "url": "https://example.com/good/text_features.npy",
+                        "path": "nuvion/anomalyclip/v0001/source/text_features.npy",
+                        "sha256": "a" * 64,
+                        "sizeBytes": 8,
+                        "expiresAt": "2026-01-01T00:00:00Z",
+                    },
+                    {
+                        "key": "manifest",
+                        "url": "https://example.com/good/manifest.json",
+                        "path": "nuvion/anomalyclip/v0001/source/gcs_manifest.json",
+                        "sha256": "b" * 64,
+                        "sizeBytes": 8,
+                        "expiresAt": "2026-01-01T00:00:00Z",
+                    },
+                ]
+            }
+        }
+
+        def fake_download(*, url: str, dst_path: Path, timeout: int = 120, max_retries: int = 3) -> None:
+            if "/bad/" in url:
+                raise RuntimeError(f"Download failed after 3 attempts: {url} (HTTP Error 400: Bad Request)")
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            dst_path.write_bytes(b"12345678")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(model_store, "_http_json", side_effect=[bad_data, good_data]) as http_mock:
+                with mock.patch.object(model_store, "_download_http_file", side_effect=fake_download) as dl_mock:
+                    with mock.patch.object(model_store, "_validate_download_integrity", return_value=None):
+                        target_dir, data = model_store.pull_model_from_server(
+                            server_base_url="https://api.nuvion-dev.plaidai.io",
+                            pointer="anomalyclip/prod",
+                            profile="light",
+                            local_dir=tmp,
+                            ttl_seconds=300,
+                            access_token="test-token",
+                        )
+            self.assertEqual(http_mock.call_count, 2)
+            self.assertGreaterEqual(dl_mock.call_count, 2)
+            self.assertEqual(len(data["artifacts"]), 2)
+            self.assertTrue((Path(target_dir) / "onnx" / "text_features.npy").exists())
+            self.assertTrue((Path(target_dir) / "metadata" / "gcs_manifest.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 내용\n- server source 모델 다운로드 중 signed URL 400/401/403 실패 시 presign 재요청 후 자동 재시도\n- 기존에 받아둔 파일은 sha256/size 검증 통과 시 재사용(reused)\n- 손상/부분 파일은 자동 정리 후 재다운로드\n- 메타데이터(downloaded_from_server.json)에 reused 필드 추가\n\n## 왜 필요한가\n- 사용자 입장에서 캐시 삭제/수동 재실행 없이 자동 복구되도록 개선\n\n## 테스트\n- python3 -m unittest discover -s tests -p 'test_*.py'\n- 신규: tests/runtime/test_model_store_selfheal.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 서명된 URL 다운로드 중 400/401/403 오류 발생 시 시스템이 자동으로 URL을 재발급하고 재시도합니다.

* **문서**
  * 자동 복구 흐름에 관한 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->