### PR TITLE
feat(model): 다운로드 진행률 로그 추가

### DIFF
--- a/nuvion_app/model_store.py
+++ b/nuvion_app/model_store.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -46,6 +47,26 @@ _DEFAULT_LOCAL_PATHS = {
     "triton_eval": "metadata/triton_eval_results.txt",
     "manifest": "metadata/gcs_manifest.json",
 }
+
+
+def _emit_model_progress(message: str) -> None:
+    try:
+        sys.stderr.write(f"[MODEL] {message}\n")
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
+def _format_size(num_bytes: int) -> str:
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(max(num_bytes, 0))
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(size)}{unit}"
+            return f"{size:.1f}{unit}"
+        size /= 1024
+    return f"{num_bytes}B"
 
 
 def resolve_default_model_dir(identifier: str) -> Path:
@@ -327,25 +348,77 @@ def _write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
-def _download_http_file(url: str, dst_path: Path, timeout: int = 120, max_retries: int = 3) -> None:
+def _download_http_file(
+    url: str,
+    dst_path: Path,
+    timeout: int = 120,
+    max_retries: int = 3,
+    progress_label: Optional[str] = None,
+) -> None:
     dst_path.parent.mkdir(parents=True, exist_ok=True)
     part_path = dst_path.with_suffix(dst_path.suffix + ".part")
 
     last_error: Optional[Exception] = None
     for attempt in range(1, max_retries + 1):
         try:
+            if progress_label:
+                _emit_model_progress(f"{progress_label}: 다운로드 시도 {attempt}/{max_retries}")
             req = urllib.request.Request(url, method="GET")
             with urllib.request.urlopen(req, timeout=timeout) as response:
                 status = response.getcode()
                 if status < 200 or status >= 300:
                     raise RuntimeError(f"HTTP status={status}")
+                content_length = response.headers.get("Content-Length")
+                total_size: Optional[int] = None
+                if content_length:
+                    try:
+                        total_size = int(content_length)
+                    except ValueError:
+                        total_size = None
                 with part_path.open("wb") as out:
+                    bytes_read = 0
+                    started_at = time.monotonic()
+                    last_reported_at = started_at
+                    last_reported_percent = -1
                     while True:
                         chunk = response.read(1024 * 1024)
                         if not chunk:
                             break
                         out.write(chunk)
+                        bytes_read += len(chunk)
+
+                        if not progress_label:
+                            continue
+
+                        now = time.monotonic()
+                        elapsed = max(now - started_at, 1e-6)
+                        speed_bps = bytes_read / elapsed
+
+                        if total_size:
+                            percent = int((bytes_read * 100) / total_size)
+                            should_report = (
+                                percent >= 100
+                                or percent >= last_reported_percent + 10
+                                or now - last_reported_at >= 2.0
+                            )
+                            if should_report:
+                                _emit_model_progress(
+                                    f"{progress_label}: {percent}% "
+                                    f"({_format_size(bytes_read)}/{_format_size(total_size)}, "
+                                    f"{_format_size(int(speed_bps))}/s)"
+                                )
+                                last_reported_percent = percent
+                                last_reported_at = now
+                        else:
+                            if now - last_reported_at >= 2.0:
+                                _emit_model_progress(
+                                    f"{progress_label}: {_format_size(bytes_read)} 다운로드됨 "
+                                    f"({_format_size(int(speed_bps))}/s)"
+                                )
+                                last_reported_at = now
             part_path.replace(dst_path)
+            if progress_label:
+                _emit_model_progress(f"{progress_label}: 다운로드 완료")
             return
         except Exception as exc:
             last_error = exc
@@ -465,7 +538,8 @@ def pull_model_from_server(
     refresh_attempts = 0
 
     downloaded: list[dict[str, Any]] = []
-    for key in required_keys:
+    total_artifacts = len(required_keys)
+    for index, key in enumerate(required_keys, start=1):
         retried_integrity = False
         while True:
             artifact = artifact_by_key[key]
@@ -490,6 +564,10 @@ def pull_model_from_server(
             if dst.exists():
                 try:
                     _validate_download_integrity(dst, expected_sha256, expected_size, key)
+                    _emit_model_progress(
+                        f"[{index}/{total_artifacts}] {key}: 기존 파일 재사용 "
+                        f"({dst.name})"
+                    )
                     downloaded.append(
                         {
                             "key": key,
@@ -507,7 +585,15 @@ def pull_model_from_server(
                     _cleanup_download_target(dst)
 
             try:
-                _download_http_file(url=url, dst_path=dst)
+                _emit_model_progress(
+                    f"[{index}/{total_artifacts}] {key}: 다운로드 시작 "
+                    f"({dst.name})"
+                )
+                _download_http_file(
+                    url=url,
+                    dst_path=dst,
+                    progress_label=f"[{index}/{total_artifacts}] {key}",
+                )
                 _validate_download_integrity(dst, expected_sha256, expected_size, key)
                 downloaded.append(
                     {

--- a/tests/runtime/test_model_store_selfheal.py
+++ b/tests/runtime/test_model_store_selfheal.py
@@ -60,7 +60,14 @@ class ModelStoreSelfHealTest(unittest.TestCase):
             }
         }
 
-        def fake_download(*, url: str, dst_path: Path, timeout: int = 120, max_retries: int = 3) -> None:
+        def fake_download(
+            *,
+            url: str,
+            dst_path: Path,
+            timeout: int = 120,
+            max_retries: int = 3,
+            progress_label: str | None = None,
+        ) -> None:
             if "/bad/" in url:
                 raise RuntimeError(f"Download failed after 3 attempts: {url} (HTTP Error 400: Bad Request)")
             dst_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## 변경사항\n- server source 모델 다운로드 시 파일별 진행률 로그 추가\n- Content-Length가 있는 경우 퍼센트/속도 표시\n- Content-Length가 없는 경우 바이트/속도 주기 출력\n- 기존 signed URL self-heal 테스트의 mock 시그니처 업데이트\n\n## 검증\n- python3 -m unittest discover -s tests -p 'test_*.py'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모델 다운로드 진행 상황 실시간 표시: 다운로드 속도, 진행률 백분율, 전송량(현재/전체) 정보 제공
  * 아티팩트 재사용 및 다운로드 시작 알림 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->