### PR TITLE
fix(triton): mac run 경고/스레드 오류 정리

### DIFF
--- a/nuvion_app/inference/pipeline.py
+++ b/nuvion_app/inference/pipeline.py
@@ -875,6 +875,7 @@ class NuvionEventState:
         self.backend = ZSAD_BACKEND
         self.zero_shot = None
         self.triton_client = None
+        self._triton_client_thread_id = None
 
         if self.backend == "siglip":
             self.zero_shot = ZeroShotAnomalyDetector(
@@ -891,13 +892,21 @@ class NuvionEventState:
             if TritonAnomalyClient is None:
                 log.warning("[TRITON] Triton client unavailable. Disable backend.")
                 self.backend = "none"
-            else:
-                self.triton_client = TritonAnomalyClient()
         else:
             self.backend = "none"
 
         self.worker_thread = threading.Thread(target=self._zsad_worker, daemon=True)
         self.worker_thread.start()
+
+    def _get_or_create_triton_client(self):
+        if TritonAnomalyClient is None:
+            raise RuntimeError("Triton client unavailable")
+
+        current_thread_id = threading.get_ident()
+        if self.triton_client is None or self._triton_client_thread_id != current_thread_id:
+            self.triton_client = TritonAnomalyClient()
+            self._triton_client_thread_id = current_thread_id
+        return self.triton_client
 
     def send_status(
         self,
@@ -1128,9 +1137,10 @@ class NuvionEventState:
                             self.last_production_at = now
                             self.report_production(1)
 
-            elif self.backend == "triton" and self.triton_client:
+            elif self.backend == "triton":
                 try:
-                    result = self.triton_client.predict(frame)
+                    triton_client = self._get_or_create_triton_client()
+                    result = triton_client.predict(frame)
                 except Exception as exc:
                     log.warning("[TRITON] inference failed: %s", exc)
                     continue


### PR DESCRIPTION
## 변경사항
- Python 3.14에서 stomper.stompbuffer invalid escape SyntaxWarning 억제
- Triton HTTP client를 worker thread에서 생성하도록 변경 (greenlet thread switch 오류 방지)

## 원인
- tritonclient(http)+gevent 객체를 생성 스레드와 추론 실행 스레드가 달라서 "Cannot switch to a different thread" 발생

## 검증
- python3 -m unittest discover -s tests -p 'test_*.py'
