### PR TITLE
feat: add config doctor, migration, and run preflight

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Config schema version (auto-migrated by `nuv-agent doctor --fix`)
+NUVION_CONFIG_SCHEMA_VERSION=2
+
 # Spring Boot 서버의 전체 주소
 NUVION_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io
 
@@ -84,7 +87,7 @@ NUVION_CLIP_CONTENT_TYPE=video/mp4
 NUVION_TRITON_MODE=anomalyclip
 NUVION_TRITON_URL=localhost:8000
 NUVION_TRITON_MODEL=image_encoder
-NUVION_TRITON_INPUT=images
+NUVION_TRITON_INPUT=image
 NUVION_TRITON_OUTPUT=OUTPUT__0
 NUVION_TRITON_INPUT_FORMAT=NCHW
 NUVION_TRITON_INPUT_WIDTH=336

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ curl -fsSL https://apt.plaidai.io/install-apt.sh | bash
 ```
 `nuv-agent setup`/`nuv-agent run` automatically bootstrap Docker/Triton/model bundle when needed.
 
+Config health check / migration:
+```bash
+# 기존 설정 파일을 최신 schema로 자동 보정하고 검증
+nuv-agent doctor --fix
+```
+
 ## Quick start (dev)
 1) Copy `.env.example` to `.env` and fill in credentials.
 2) Run locally:
@@ -198,6 +204,7 @@ For dev, `.env` in the repo is used automatically.
 - `NUVION_MODEL_GCS_POINTER_URI`: GCS pointer JSON URI (default: `gs://nuv-model/pointers/anomalyclip/prod.json`)
 - `NUVION_MODEL_PROFILE`: pull-model 프로필 (`runtime|light|full`)
 - `NUVION_MODEL_DIR`: pull-model 기본 저장 루트
+- `NUVION_CONFIG_SCHEMA_VERSION`: config schema 버전 (`doctor --fix`로 자동 보정)
 - `NUVION_RUNTIME_BOOTSTRAP_ENABLED`: setup/run bootstrap 전체 on/off
 - `NUVION_HOMEBREW_AUTOINSTALL`: macOS Homebrew 자동 설치 허용
 - `NUVION_DOCKER_AUTOINSTALL`: Docker/Colima(또는 docker.io) 자동 설치 허용

--- a/nuvion_app/cli.py
+++ b/nuvion_app/cli.py
@@ -26,6 +26,7 @@ from nuvion_app.model_store import (
     pull_model_from_server,
     resolve_default_model_dir,
 )
+from nuvion_app.runtime.config_guard import ensure_runtime_config, guard_config, print_report
 from nuvion_app.runtime.inference_mode import normalize_backend, normalize_siglip_device
 
 
@@ -146,6 +147,10 @@ def _build_parser() -> argparse.ArgumentParser:
         help="SigLIP device preference: auto|mps|cuda|cpu",
     )
 
+    doctor_parser = subparsers.add_parser("doctor", help="Validate/migrate agent config")
+    doctor_parser.add_argument("--config", help="Path to config env file")
+    doctor_parser.add_argument("--fix", action="store_true", help="Apply automatic migration fixes")
+
     return parser
 
 
@@ -187,7 +192,8 @@ def main() -> None:
         return
 
     if args.command == "run":
-        load_env(args.config)
+        config_path = resolve_config_path(args.config)
+        load_env(str(config_path))
         if args.backend:
             raw_backend = args.backend.strip().lower()
             os.environ["NUVION_ZSAD_BACKEND"] = normalize_backend(raw_backend, default="triton")
@@ -195,6 +201,14 @@ def main() -> None:
                 os.environ["NUVION_ZERO_SHOT_DEVICE"] = "mps"
         if args.siglip_device:
             os.environ["NUVION_ZERO_SHOT_DEVICE"] = normalize_siglip_device(args.siglip_device, default="auto")
+
+        try:
+            ensure_runtime_config(config_path=config_path, stage="run", apply_fixes=True)
+        except Exception as exc:
+            sys.stderr.write(f"Config preflight failed: {exc}\n")
+            sys.stderr.write("Run `nuv-agent doctor --fix` and retry.\n")
+            sys.exit(2)
+
         from nuvion_app.inference.main import main as run_main
 
         run_main()
@@ -286,6 +300,16 @@ def main() -> None:
         sys.stdout.write(f"  NUVION_ZSAD_BACKEND={values['NUVION_ZSAD_BACKEND']}\n")
         sys.stdout.write(f"  NUVION_ZERO_SHOT_DEVICE={values['NUVION_ZERO_SHOT_DEVICE']}\n")
         return
+
+    if args.command == "doctor":
+        config_path = resolve_config_path(args.config)
+        report = guard_config(config_path=config_path, apply_fixes=args.fix)
+        print_report(report)
+        if report.ok:
+            sys.stdout.write("[DOCTOR] result: OK\n")
+            return
+        sys.stderr.write("[DOCTOR] result: FAILED\n")
+        sys.exit(2)
 
     parser.print_help()
 

--- a/nuvion_app/config.py
+++ b/nuvion_app/config.py
@@ -37,6 +37,7 @@ REQUIRED_KEYS = {
 PLACEHOLDER_VALUES = {"***"}
 
 _LOADED = False
+_LOADED_PATH: Optional[Path] = None
 
 
 def _is_placeholder(value: Optional[str]) -> bool:
@@ -137,12 +138,17 @@ def resolve_config_path(explicit: Optional[str] = None) -> Path:
 
 def load_env(path: Optional[str] = None) -> Path:
     global _LOADED
-    if _LOADED:
-        return resolve_config_path(path)
+    global _LOADED_PATH
     config_path = resolve_config_path(path)
-    os.environ.setdefault("NUV_AGENT_CONFIG", str(config_path))
-    load_dotenv(config_path, override=False)
+    if _LOADED and _LOADED_PATH == config_path:
+        return config_path
+
+    override = _LOADED and _LOADED_PATH is not None and _LOADED_PATH != config_path
+    os.environ["NUV_AGENT_CONFIG"] = str(config_path)
+    load_dotenv(config_path, override=override)
+
     _LOADED = True
+    _LOADED_PATH = config_path
     return config_path
 
 
@@ -1387,8 +1393,10 @@ def setup_config(
         for key, value in read_env(path).items():
             os.environ[key] = value
 
+        from nuvion_app.runtime.config_guard import ensure_runtime_config
         from nuvion_app.runtime.bootstrap import ensure_ready
 
+        ensure_runtime_config(config_path=path, stage="setup", apply_fixes=True)
         ready = ensure_ready(stage="setup")
         if ready:
             print("Runtime bootstrap: ready")

--- a/nuvion_app/config_template.env
+++ b/nuvion_app/config_template.env
@@ -1,3 +1,6 @@
+# Config schema version (auto-migrated by `nuv-agent doctor --fix`)
+NUVION_CONFIG_SCHEMA_VERSION=2
+
 # Spring Boot 서버의 전체 주소
 NUVION_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io
 

--- a/nuvion_app/runtime/config_guard.py
+++ b/nuvion_app/runtime/config_guard.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from nuvion_app.config import REQUIRED_KEYS, load_template, read_env, write_env
+from nuvion_app.model_store import DEFAULT_MODEL_PROFILE, DEFAULT_MODEL_SOURCE
+from nuvion_app.runtime.inference_mode import normalize_backend, normalize_siglip_device
+
+CURRENT_CONFIG_SCHEMA_VERSION = "2"
+_VALID_MODEL_SOURCES = {"server", "gcs"}
+_VALID_MODEL_PROFILES = {"runtime", "light", "full"}
+_VALID_TRITON_INPUT_FORMATS = {"NCHW", "NHWC"}
+_SECRET_MARKERS = ("PASSWORD", "TOKEN", "SECRET")
+
+
+@dataclass
+class ConfigIssue:
+    key: str
+    message: str
+
+
+@dataclass
+class ConfigGuardResult:
+    config_path: Path
+    changed: List[str] = field(default_factory=list)
+    warnings: List[ConfigIssue] = field(default_factory=list)
+    errors: List[ConfigIssue] = field(default_factory=list)
+    values: Dict[str, str] = field(default_factory=dict)
+    env_overrides: Dict[str, Tuple[str, str]] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _is_placeholder(value: str | None) -> bool:
+    if value is None:
+        return True
+    stripped = value.strip()
+    if not stripped:
+        return True
+    if stripped == "***":
+        return True
+    if stripped.startswith("<") and stripped.endswith(">"):
+        return True
+    return False
+
+
+def _mask_if_secret(key: str, value: str) -> str:
+    if any(marker in key for marker in _SECRET_MARKERS):
+        return "***"
+    return value
+
+
+def _merge_defaults(fields: List[Dict[str, str]], existing: Dict[str, str]) -> Dict[str, str]:
+    merged = dict(existing)
+    for field in fields:
+        key = field["key"]
+        if key not in merged:
+            merged[key] = field["default"]
+    return merged
+
+
+def _normalize_int(value: str, default: int) -> int:
+    try:
+        parsed = int(str(value).strip())
+    except Exception:
+        return default
+    if parsed <= 0:
+        return default
+    return parsed
+
+
+def _apply_migrations(values: Dict[str, str]) -> List[str]:
+    changed: List[str] = []
+
+    def update(key: str, new_value: str, reason: str) -> None:
+        old_value = values.get(key, "")
+        if old_value == new_value:
+            return
+        values[key] = new_value
+        changed.append(f"{key}: {reason} ({old_value!r} -> {new_value!r})")
+
+    if values.get("NUVION_CONFIG_SCHEMA_VERSION", "").strip() != CURRENT_CONFIG_SCHEMA_VERSION:
+        update("NUVION_CONFIG_SCHEMA_VERSION", CURRENT_CONFIG_SCHEMA_VERSION, "schema version update")
+
+    raw_backend = (values.get("NUVION_ZSAD_BACKEND", "triton") or "triton").strip().lower()
+    backend = normalize_backend(raw_backend, default="triton")
+    if raw_backend != backend:
+        update("NUVION_ZSAD_BACKEND", backend, "normalize backend value")
+
+    if values.get("NUVION_TRITON_INPUT", "").strip() == "images":
+        update("NUVION_TRITON_INPUT", "image", "legacy triton input alias")
+
+    source = (values.get("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE) or DEFAULT_MODEL_SOURCE).strip().lower()
+    if source not in _VALID_MODEL_SOURCES:
+        update("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE, "invalid model source fallback")
+
+    profile = (values.get("NUVION_MODEL_PROFILE", DEFAULT_MODEL_PROFILE) or DEFAULT_MODEL_PROFILE).strip().lower()
+    if profile not in _VALID_MODEL_PROFILES:
+        update("NUVION_MODEL_PROFILE", DEFAULT_MODEL_PROFILE, "invalid model profile fallback")
+
+    jetson_profile = (values.get("NUVION_TRITON_JETSON_PROFILE", "") or "").strip().lower()
+    if not jetson_profile:
+        update("NUVION_TRITON_JETSON_PROFILE", "runtime", "set default Jetson profile")
+
+    triton_input_format = (values.get("NUVION_TRITON_INPUT_FORMAT", "") or "").strip().upper()
+    if triton_input_format not in _VALID_TRITON_INPUT_FORMATS:
+        update("NUVION_TRITON_INPUT_FORMAT", "NCHW", "invalid triton input format fallback")
+
+    width = _normalize_int(values.get("NUVION_TRITON_INPUT_WIDTH", ""), 336)
+    if str(width) != str(values.get("NUVION_TRITON_INPUT_WIDTH", "")):
+        update("NUVION_TRITON_INPUT_WIDTH", str(width), "normalize triton input width")
+
+    height = _normalize_int(values.get("NUVION_TRITON_INPUT_HEIGHT", ""), 336)
+    if str(height) != str(values.get("NUVION_TRITON_INPUT_HEIGHT", "")):
+        update("NUVION_TRITON_INPUT_HEIGHT", str(height), "normalize triton input height")
+
+    base_url = (values.get("NUVION_MODEL_SERVER_BASE_URL", "") or "").strip()
+    if not base_url:
+        fallback_base = (values.get("NUVION_SERVER_BASE_URL", "") or "").strip()
+        if fallback_base:
+            update("NUVION_MODEL_SERVER_BASE_URL", fallback_base, "fallback to NUVION_SERVER_BASE_URL")
+
+    raw_siglip_device = (values.get("NUVION_ZERO_SHOT_DEVICE", "auto") or "auto").strip().lower()
+    normalized_siglip = normalize_siglip_device(raw_siglip_device, default="auto")
+    if raw_siglip_device != normalized_siglip:
+        update("NUVION_ZERO_SHOT_DEVICE", normalized_siglip, "normalize zero-shot device")
+
+    return changed
+
+
+def _collect_effective_values(fields: List[Dict[str, str]], file_values: Dict[str, str]) -> tuple[Dict[str, str], Dict[str, Tuple[str, str]]]:
+    effective = dict(file_values)
+    overrides: Dict[str, Tuple[str, str]] = {}
+    for field in fields:
+        key = field["key"]
+        env_value = os.getenv(key)
+        if env_value is None:
+            continue
+        file_value = file_values.get(key, "")
+        if env_value != file_value:
+            overrides[key] = (file_value, env_value)
+        effective[key] = env_value
+    return effective, overrides
+
+
+def _validate_values(values: Dict[str, str]) -> tuple[List[ConfigIssue], List[ConfigIssue]]:
+    warnings: List[ConfigIssue] = []
+    errors: List[ConfigIssue] = []
+
+    for key in REQUIRED_KEYS:
+        if _is_placeholder(values.get(key)):
+            errors.append(ConfigIssue(key=key, message="필수 값이 비어있거나 placeholder입니다."))
+
+    backend = normalize_backend(values.get("NUVION_ZSAD_BACKEND", "triton"), default="triton")
+    source = (values.get("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE) or DEFAULT_MODEL_SOURCE).strip().lower()
+
+    if source not in _VALID_MODEL_SOURCES:
+        errors.append(ConfigIssue(key="NUVION_MODEL_SOURCE", message="지원하지 않는 모델 source입니다. (server|gcs)"))
+
+    if backend == "triton":
+        triton_url = (values.get("NUVION_TRITON_URL", "") or "").strip()
+        if not triton_url:
+            errors.append(ConfigIssue(key="NUVION_TRITON_URL", message="Triton backend 사용 시 NUVION_TRITON_URL이 필요합니다."))
+
+        triton_input = (values.get("NUVION_TRITON_INPUT", "") or "").strip()
+        if not triton_input:
+            errors.append(ConfigIssue(key="NUVION_TRITON_INPUT", message="Triton backend 사용 시 입력 텐서 이름이 필요합니다."))
+
+        input_format = (values.get("NUVION_TRITON_INPUT_FORMAT", "") or "").strip().upper()
+        if input_format not in _VALID_TRITON_INPUT_FORMATS:
+            errors.append(ConfigIssue(key="NUVION_TRITON_INPUT_FORMAT", message="입력 포맷은 NCHW 또는 NHWC여야 합니다."))
+
+        for key in ("NUVION_TRITON_INPUT_WIDTH", "NUVION_TRITON_INPUT_HEIGHT"):
+            try:
+                parsed = int(str(values.get(key, "")).strip())
+                if parsed <= 0:
+                    raise ValueError
+            except Exception:
+                errors.append(ConfigIssue(key=key, message="양수 정수여야 합니다."))
+
+        if source == "server":
+            pointer = (values.get("NUVION_MODEL_POINTER", "") or "").strip()
+            if not pointer:
+                errors.append(ConfigIssue(key="NUVION_MODEL_POINTER", message="server source 사용 시 pointer가 필요합니다."))
+            server_url = (values.get("NUVION_MODEL_SERVER_BASE_URL", "") or "").strip()
+            if not server_url:
+                errors.append(ConfigIssue(key="NUVION_MODEL_SERVER_BASE_URL", message="server source 사용 시 base URL이 필요합니다."))
+
+        if source == "gcs":
+            pointer_uri = (values.get("NUVION_MODEL_GCS_POINTER_URI", "") or "").strip()
+            if not pointer_uri.startswith("gs://"):
+                errors.append(ConfigIssue(key="NUVION_MODEL_GCS_POINTER_URI", message="gcs source 사용 시 gs:// URI가 필요합니다."))
+
+        mode = (values.get("NUVION_TRITON_MODE", "generic") or "generic").strip().lower()
+        if mode == "anomalyclip":
+            text_features = (values.get("NUVION_TRITON_TEXT_FEATURES", "") or "").strip()
+            if not text_features:
+                warnings.append(
+                    ConfigIssue(
+                        key="NUVION_TRITON_TEXT_FEATURES",
+                        message="anomalyclip 모드에서는 text_features 경로가 필요합니다. (auto-pull로 채워질 수 있음)",
+                    )
+                )
+            if values.get("NUVION_TRITON_INPUT", "").strip() == "images":
+                warnings.append(
+                    ConfigIssue(
+                        key="NUVION_TRITON_INPUT",
+                        message="legacy 입력 이름(images)이 감지되었습니다. image 사용을 권장합니다.",
+                    )
+                )
+
+    return warnings, errors
+
+
+def guard_config(config_path: Path, apply_fixes: bool = True) -> ConfigGuardResult:
+    lines, fields = load_template()
+    existing = read_env(config_path)
+    merged = _merge_defaults(fields, existing)
+    changed: List[str] = []
+
+    if apply_fixes:
+        changed = _apply_migrations(merged)
+        if changed:
+            write_env(config_path, lines, merged)
+
+    effective_values, overrides = _collect_effective_values(fields, merged)
+    warnings, errors = _validate_values(effective_values)
+
+    return ConfigGuardResult(
+        config_path=config_path,
+        changed=changed,
+        warnings=warnings,
+        errors=errors,
+        values=effective_values,
+        env_overrides=overrides,
+    )
+
+
+def print_report(report: ConfigGuardResult) -> None:
+    print(f"[DOCTOR] config: {report.config_path}")
+    schema = report.values.get("NUVION_CONFIG_SCHEMA_VERSION", "<unset>")
+    print(f"[DOCTOR] schema: {schema}")
+    print(f"[DOCTOR] changed: {len(report.changed)}")
+    if report.changed:
+        for entry in report.changed:
+            print(f"  - {entry}")
+
+    print(f"[DOCTOR] env overrides: {len(report.env_overrides)}")
+    for key, (file_value, env_value) in sorted(report.env_overrides.items()):
+        print(
+            f"  - {key}: file={_mask_if_secret(key, file_value)!r}, "
+            f"env={_mask_if_secret(key, env_value)!r}"
+        )
+
+    print(f"[DOCTOR] warnings: {len(report.warnings)}")
+    for issue in report.warnings:
+        print(f"  - [{issue.key}] {issue.message}")
+
+    print(f"[DOCTOR] errors: {len(report.errors)}")
+    for issue in report.errors:
+        print(f"  - [{issue.key}] {issue.message}")
+
+
+def ensure_runtime_config(config_path: Path, stage: str, apply_fixes: bool = True) -> ConfigGuardResult:
+    report = guard_config(config_path=config_path, apply_fixes=apply_fixes)
+    if report.changed:
+        print(f"[BOOTSTRAP] stage={stage} config migration applied: {len(report.changed)} change(s)")
+    if report.env_overrides:
+        print(f"[BOOTSTRAP] stage={stage} env override detected: {len(report.env_overrides)} key(s)")
+
+    # Apply effective runtime values to current process.
+    for key, value in report.values.items():
+        os.environ[key] = value
+
+    if report.errors:
+        details = "; ".join(f"{issue.key}: {issue.message}" for issue in report.errors)
+        raise RuntimeError(f"config preflight failed: {details}")
+    return report

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -39,6 +39,7 @@ if command -v python3 >/dev/null 2>&1; then
   python3 -m venv --clear --system-site-packages /opt/nuv-agent/venv
   /opt/nuv-agent/venv/bin/pip install --no-cache-dir --upgrade pip >/dev/null
   /opt/nuv-agent/venv/bin/pip install --no-cache-dir --upgrade "/opt/nuv-agent/src[zsad,triton]" >/dev/null
+  /opt/nuv-agent/venv/bin/python -m nuvion_app.cli doctor --config /etc/nuv-agent/agent.env --fix >/dev/null 2>&1 || true
 fi
 
 systemctl daemon-reload || true

--- a/tests/runtime/test_config_guard.py
+++ b/tests/runtime/test_config_guard.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from nuvion_app.runtime.config_guard import CURRENT_CONFIG_SCHEMA_VERSION, guard_config
+
+
+class ConfigGuardTest(unittest.TestCase):
+    def test_guard_applies_legacy_migrations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "agent.env"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "NUVION_SERVER_BASE_URL=https://api.example.com",
+                        "NUVION_DEVICE_USERNAME=device-1",
+                        "NUVION_DEVICE_PASSWORD=secret",
+                        "NUVION_RTP_REMOTE_IP=1.2.3.4",
+                        "NUVION_TRITON_INPUT=images",
+                        "NUVION_TRITON_INPUT_FORMAT=INVALID",
+                        "NUVION_MODEL_SOURCE=invalid",
+                        "",
+                    ]
+                )
+            )
+
+            report = guard_config(config_path=config_path, apply_fixes=True)
+
+            self.assertTrue(report.ok)
+            self.assertEqual(report.values["NUVION_TRITON_INPUT"], "image")
+            self.assertEqual(report.values["NUVION_TRITON_INPUT_FORMAT"], "NCHW")
+            self.assertEqual(report.values["NUVION_MODEL_SOURCE"], "server")
+            self.assertEqual(report.values["NUVION_CONFIG_SCHEMA_VERSION"], CURRENT_CONFIG_SCHEMA_VERSION)
+            self.assertGreater(len(report.changed), 0)
+
+    def test_guard_detects_required_value_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "agent.env"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "NUVION_SERVER_BASE_URL=https://api.example.com",
+                        "NUVION_DEVICE_USERNAME=device-1",
+                        "NUVION_DEVICE_PASSWORD=***",
+                        "NUVION_RTP_REMOTE_IP=1.2.3.4",
+                        "",
+                    ]
+                )
+            )
+            report = guard_config(config_path=config_path, apply_fixes=True)
+            self.assertFalse(report.ok)
+            self.assertTrue(any(issue.key == "NUVION_DEVICE_PASSWORD" for issue in report.errors))
+
+    def test_guard_reports_env_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "agent.env"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "NUVION_SERVER_BASE_URL=https://api.example.com",
+                        "NUVION_DEVICE_USERNAME=device-1",
+                        "NUVION_DEVICE_PASSWORD=secret",
+                        "NUVION_RTP_REMOTE_IP=1.2.3.4",
+                        "NUVION_TRITON_INPUT=image",
+                        "",
+                    ]
+                )
+            )
+            with mock.patch.dict(os.environ, {"NUVION_TRITON_INPUT": "images"}, clear=False):
+                report = guard_config(config_path=config_path, apply_fixes=False)
+            self.assertIn("NUVION_TRITON_INPUT", report.env_overrides)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_config_loader.py
+++ b/tests/runtime/test_config_loader.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from nuvion_app import config as config_module
+
+
+class ConfigLoaderTest(unittest.TestCase):
+    def setUp(self) -> None:
+        config_module._LOADED = False
+        config_module._LOADED_PATH = None
+        for key in ("NUV_AGENT_CONFIG", "NUVION_DEVICE_USERNAME"):
+            os.environ.pop(key, None)
+
+    def test_load_env_reloads_when_config_path_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path1 = Path(tmp) / "one.env"
+            path2 = Path(tmp) / "two.env"
+            path1.write_text("NUVION_DEVICE_USERNAME=device-one\n")
+            path2.write_text("NUVION_DEVICE_USERNAME=device-two\n")
+
+            config_module.load_env(str(path1))
+            self.assertEqual(os.getenv("NUVION_DEVICE_USERNAME"), "device-one")
+
+            config_module.load_env(str(path2))
+            self.assertEqual(os.getenv("NUVION_DEVICE_USERNAME"), "device-two")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `nuv-agent doctor` command for config validation/migration
- introduce runtime config guard with schema versioning, legacy key/value migration, and fail-fast error checks
- apply config preflight in run and setup flow, plus apt postinst auto-migration hook
- fix .env.example triton input default (images -> image) and add schema version key

## Test
- python3 -m unittest discover -s tests -p 'test_*.py'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * `nuv-agent doctor --fix` 명령 추가: 설정 자동 검증 및 수정 기능 제공
  * 설정 스키마 버전 관리 도입으로 이전 호환성 자동 지원
  * 시작 시 설정 상태 자동 검증 및 필요한 마이그레이션 자동 적용

* **변경 사항**
  * Triton 입력 설정명 표준화로 일관성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->