### PR TITLE
feat(agent): 전시장 데모 모드(run --demo) + 설치형 데모 영상

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,43 @@ Optional build args (in `nuvion_app/inference/Dockerfile.inference`):
 - `INSTALL_ZSAD_DEPS=true`
 - `INSTALL_TRITON_DEPS=true`
 
+## Exhibition demo mode
+기본 런타임은 카메라 입력을 사용하고, `--demo`를 주면 로컬 데모 영상 파일 입력으로 전환됩니다.
+
+일반 모드:
+```bash
+nuv-agent run
+```
+
+데모 모드:
+```bash
+NUVION_DEMO_VIDEO_PATH=/opt/nuvion/demo/demo.mp4 nuv-agent run --demo
+```
+
+선택적으로 이번 실행에만 영상 경로를 override 할 수 있습니다:
+```bash
+nuv-agent run --demo --demo-video /opt/nuvion/demo/demo.mp4
+```
+
+정책:
+- 데모 모드에서 `NUVION_DEMO_VIDEO_PATH`가 비어있으면 설치 기본 경로의 샘플 영상을 자동 탐색합니다.
+  - Linux/deb: `/var/lib/nuv-agent/demo/exhibition-demo.webm`
+  - macOS/Homebrew: `/opt/homebrew/var/nuv-agent/demo/exhibition-demo.webm` 또는 `/usr/local/var/nuv-agent/demo/exhibition-demo.webm`
+- Debian 설치 시 `NUVION_DEMO_VIDEO_URL` 환경변수를 주면 postinst 기본 다운로드 URL을 원하는 영상으로 교체할 수 있습니다.
+- 경로 지정값/기본 경로 모두 유효한 영상이 없으면 즉시 실패(fail-fast)합니다.
+- 데모 영상은 EOS 시 자동으로 처음부터 재생됩니다(`NUVION_DEMO_LOOP=true`).
+- anomaly 이벤트 message에는 `[DEMO]` prefix가 붙습니다(기본 `NUVION_DEMO_TAG=[DEMO]`).
+
+기본 샘플 영상 출처(CC BY 3.0):
+- Gigaset Smartphone Production IV Quality Inspection (Wikimedia Commons)
+  - https://commons.wikimedia.org/wiki/File:Gigaset_Smartphone_Production_IV_Quality_Inspection.webm
+
+전시장용 대체 영상(직접 경로 지정 권장):
+- Assembly line (CC BY 4.0)
+  - https://commons.wikimedia.org/wiki/File:Assembly_line.webm
+- Animal feed pellet production line (CC BY-SA 4.0)
+  - https://commons.wikimedia.org/wiki/File:Animal_feed_pellet_production_line.webm
+
 ## Setup UI (device)
 If a display is available, run:
 ```bash
@@ -157,7 +194,7 @@ device credentials automatically (your account credentials are not stored on the
 It also includes:
 - **Inference Mode** quick selector (`Triton | SigLIP | SigLIP+MPS | None`)
 - **Conditional settings view** (only backend-relevant fields are shown)
-- **Preflight Check** button (server login / triton health / camera source / RTP target)
+- **Preflight Check** button (server login / triton health / camera source or demo video source / RTP target)
 - **Environment override warning** when shell env values override file values
 
 For headless devices:
@@ -194,6 +231,11 @@ For dev, `.env` in the repo is used automatically.
 
 ## Device configuration
 - `NUVION_VIDEO_SOURCE`: USB webcam path (e.g., `/dev/video0`) or `rpi` for Pi camera
+- `NUVION_DEMO_MODE`: 데모 모드 활성화 (`true|false`)
+- `NUVION_DEMO_VIDEO_PATH`: 데모 영상 파일 경로 (비어있으면 설치 기본 샘플 경로 자동 탐색)
+- `NUVION_DEMO_LOOP`: 데모 영상 EOS 시 반복 재생 여부 (`true|false`, 기본 `true`)
+- `NUVION_DEMO_TAG`: 데모 이벤트 메시지 prefix (기본 `[DEMO]`)
+- `NUVION_DEMO_VIDEO_FALLBACK_PATHS`: 추가 fallback 경로 CSV (예: `/data/demo1.webm,/data/demo2.mp4`)
 - `NUVION_ANOMALY_LABELS`: comma-separated labels treated as anomalies
 - `NUVION_PRODUCTION_LABELS`: comma-separated labels counted for production
 - `NUVION_DEVICE_STATE_INTERVAL_SEC`: `/app/device/state` heartbeat 주기(초, 기본 `30`)
@@ -248,6 +290,9 @@ macOS note: use `NUVION_VIDEO_SOURCE=avf` (default camera) or `avf:<index>` to s
 Connectivity 보고 정책:
 - macOS는 `airport -I`, Linux(Jetson)는 `iw dev <iface> link`에서 RSSI를 수집합니다.
 - 공통으로 `ping` 평균 RTT/패킷손실을 수집합니다.
+- `uplinkKbps/downlinkKbps`는 OS별 무선 링크 bitrate를 기반으로 채웁니다.
+  - macOS: `airport -I`의 `lastTxRate/maxRate` 기반
+  - Linux/Jetson: `iw ... link`의 `tx bitrate/rx bitrate` 기반
 - `quality` 전이(`GOOD ↔ POOR`) 시점에만 `/app/device/connectivity`를 송신합니다.
 
 Optional deps:

--- a/nuvion_app/cli.py
+++ b/nuvion_app/cli.py
@@ -66,6 +66,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Override backend for this run: triton|siglip|mps(alias for siglip+mps)|none",
     )
     run_parser.add_argument(
+        "--demo",
+        action="store_true",
+        help="Run in demo mode using a prerecorded local video source",
+    )
+    run_parser.add_argument(
+        "--demo-video",
+        help="Demo video file path (overrides NUVION_DEMO_VIDEO_PATH for this run)",
+    )
+    run_parser.add_argument(
         "--siglip-device",
         choices=_SIGLIP_DEVICE_CHOICES,
         help="SigLIP device preference when backend is siglip: auto|mps|cuda|cpu",
@@ -192,8 +201,15 @@ def main() -> None:
         return
 
     if args.command == "run":
+        if args.demo_video and not args.demo:
+            parser.error("--demo-video requires --demo")
+
         config_path = resolve_config_path(args.config)
         load_env(str(config_path))
+        if args.demo:
+            os.environ["NUVION_DEMO_MODE"] = "true"
+        if args.demo_video:
+            os.environ["NUVION_DEMO_VIDEO_PATH"] = args.demo_video
         if args.backend:
             raw_backend = args.backend.strip().lower()
             os.environ["NUVION_ZSAD_BACKEND"] = normalize_backend(raw_backend, default="triton")

--- a/nuvion_app/config.py
+++ b/nuvion_app/config.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from dotenv import dotenv_values, load_dotenv
+from nuvion_app.inference.video_source import resolve_demo_video_path
 
 
 DEFAULT_PORT = 8088
@@ -385,6 +386,12 @@ def _has_display() -> bool:
     return bool(os.getenv("DISPLAY") or os.getenv("WAYLAND_DISPLAY"))
 
 
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _field_group(key: str) -> str:
     if key.startswith("NUVION_TRITON_"):
         return "triton"
@@ -523,6 +530,18 @@ def _check_camera_source(values: Dict[str, str]) -> Dict[str, str]:
     }
 
 
+def _check_demo_video_source(values: Dict[str, str]) -> Dict[str, str]:
+    try:
+        path = resolve_demo_video_path(values.get("NUVION_DEMO_VIDEO_PATH"))
+    except ValueError as exc:
+        return {
+            "name": "Demo video source",
+            "status": "fail",
+            "detail": str(exc),
+        }
+    return {"name": "Demo video source", "status": "pass", "detail": f"Demo video file is ready: {path}"}
+
+
 def _check_rtp_target(values: Dict[str, str]) -> Dict[str, str]:
     rtp_ip = (values.get("NUVION_RTP_REMOTE_IP") or "").strip()
     if not rtp_ip:
@@ -547,10 +566,12 @@ def _check_rtp_target(values: Dict[str, str]) -> Dict[str, str]:
 
 
 def _run_preflight(values: Dict[str, str]) -> Dict[str, object]:
+    demo_mode = _is_truthy(values.get("NUVION_DEMO_MODE", "false"))
+    source_check = _check_demo_video_source(values) if demo_mode else _check_camera_source(values)
     checks = [
         _check_server_login(values),
         _check_triton_health(values),
-        _check_camera_source(values),
+        source_check,
         _check_rtp_target(values),
     ]
     has_fail = any(check["status"] == "fail" for check in checks)

--- a/nuvion_app/config_template.env
+++ b/nuvion_app/config_template.env
@@ -18,6 +18,13 @@ NUVION_H264_LEVEL_ASYMMETRY_ALLOWED=1
 
 # Video source (USB webcam by default). Use "rpi" for Pi camera.
 NUVION_VIDEO_SOURCE=/dev/video0
+# Demo mode (run --demo): use prerecorded local video input instead of camera
+NUVION_DEMO_MODE=false
+NUVION_DEMO_VIDEO_PATH=
+NUVION_DEMO_LOOP=true
+NUVION_DEMO_TAG=[DEMO]
+# Optional CSV fallback paths when NUVION_DEMO_VIDEO_PATH is empty
+# NUVION_DEMO_VIDEO_FALLBACK_PATHS=/var/lib/nuv-agent/demo/exhibition-demo.webm
 
 # Detection labels
 NUVION_ANOMALY_LABELS=

--- a/nuvion_app/inference/connectivity.py
+++ b/nuvion_app/inference/connectivity.py
@@ -11,6 +11,10 @@ AIRPORT_DEFAULT_PATH = "/System/Library/PrivateFrameworks/Apple80211.framework/V
 
 RSSI_AIRPORT_PATTERN = re.compile(r"agrCtlRSSI:\s*(-?\d+)")
 RSSI_IW_PATTERN = re.compile(r"signal:\s*(-?\d+)\s*dBm", re.IGNORECASE)
+AIRPORT_LAST_TX_RATE_PATTERN = re.compile(r"lastTxRate:\s*([0-9.]+)", re.IGNORECASE)
+AIRPORT_MAX_RATE_PATTERN = re.compile(r"maxRate:\s*([0-9.]+)", re.IGNORECASE)
+IW_TX_BITRATE_PATTERN = re.compile(r"tx bitrate:\s*([0-9.]+)\s*([KMG])?bit/s", re.IGNORECASE)
+IW_RX_BITRATE_PATTERN = re.compile(r"rx bitrate:\s*([0-9.]+)\s*([KMG])?bit/s", re.IGNORECASE)
 PING_PACKET_LOSS_PATTERN = re.compile(r"(\d+(?:\.\d+)?)%\s*packet loss", re.IGNORECASE)
 PING_RTT_PATTERN = re.compile(
     r"(?:round-trip|rtt)[^=]*=\s*([0-9.]+)/([0-9.]+)/([0-9.]+)/([0-9.]+)\s*ms",
@@ -52,6 +56,42 @@ def parse_iw_link_output_for_rssi(output: str | None) -> int | None:
         return int(match.group(1))
     except ValueError:
         return None
+
+
+def _to_kbps(value: str, unit: str | None) -> int | None:
+    try:
+        numeric = float(value)
+    except ValueError:
+        return None
+    normalized = (unit or "K").upper()
+    factor = {"K": 1.0, "M": 1000.0, "G": 1_000_000.0}.get(normalized)
+    if factor is None:
+        return None
+    return int(round(numeric * factor))
+
+
+def parse_airport_output_for_bitrate_kbps(output: str | None) -> tuple[int | None, int | None]:
+    if not output:
+        return None, None
+
+    tx_match = AIRPORT_LAST_TX_RATE_PATTERN.search(output)
+    max_match = AIRPORT_MAX_RATE_PATTERN.search(output)
+
+    uplink_kbps = _to_kbps(tx_match.group(1), "M") if tx_match else None
+    # airport 출력은 downlink 지표가 별도로 없어 maxRate 또는 lastTxRate를 대체 사용
+    downlink_kbps = _to_kbps(max_match.group(1), "M") if max_match else uplink_kbps
+    return uplink_kbps, downlink_kbps
+
+
+def parse_iw_link_output_for_bitrate_kbps(output: str | None) -> tuple[int | None, int | None]:
+    if not output:
+        return None, None
+    tx_match = IW_TX_BITRATE_PATTERN.search(output)
+    rx_match = IW_RX_BITRATE_PATTERN.search(output)
+
+    uplink_kbps = _to_kbps(tx_match.group(1), tx_match.group(2)) if tx_match else None
+    downlink_kbps = _to_kbps(rx_match.group(1), rx_match.group(2)) if rx_match else None
+    return uplink_kbps, downlink_kbps
 
 
 def parse_ping_output(output: str | None) -> tuple[float | None, int | None]:
@@ -137,6 +177,30 @@ def collect_ping_metrics(
     return parse_ping_output(output)
 
 
+def collect_link_bitrate_kbps(
+    wifi_interface: str | None = None,
+    platform_name: str | None = None,
+    run_command_fn: Callable[[list[str], float], str | None] = run_command_output,
+) -> tuple[int | None, int | None]:
+    platform = platform_name or sys.platform
+
+    if platform == "darwin":
+        airport_path = os.getenv("NUVION_AIRPORT_PATH", AIRPORT_DEFAULT_PATH)
+        output = run_command_fn([airport_path, "-I"], 2.0)
+        if output is None and airport_path != "airport":
+            output = run_command_fn(["airport", "-I"], 2.0)
+        return parse_airport_output_for_bitrate_kbps(output)
+
+    if platform.startswith("linux"):
+        iface = (wifi_interface or "").strip() or detect_linux_wifi_interface(run_command_fn)
+        if not iface:
+            return None, None
+        output = run_command_fn(["iw", "dev", iface, "link"], 2.0)
+        return parse_iw_link_output_for_bitrate_kbps(output)
+
+    return None, None
+
+
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -157,6 +221,7 @@ class ConnectivityReporter:
         min_send_interval_sec: float = 30.0,
         rssi_collector: Callable[[], int | None] | None = None,
         ping_collector: Callable[[], tuple[float | None, int | None]] | None = None,
+        bitrate_collector: Callable[[], tuple[int | None, int | None]] | None = None,
         clock: Callable[[], float] | None = None,
         measured_at_factory: Callable[[], str] | None = None,
     ):
@@ -173,6 +238,9 @@ class ConnectivityReporter:
         self._ping_collector = ping_collector or (
             lambda: collect_ping_metrics(self.target_host)
         )
+        self._bitrate_collector = bitrate_collector or (
+            lambda: collect_link_bitrate_kbps(wifi_interface=self.wifi_interface)
+        )
 
         self._last_quality: str | None = None
         self._last_sent_at: float = 0.0
@@ -180,6 +248,7 @@ class ConnectivityReporter:
     def build_transition_payload(self) -> dict | None:
         rssi_dbm = self._rssi_collector()
         packet_loss_pct, rtt_ms = self._ping_collector()
+        uplink_kbps, downlink_kbps = self._bitrate_collector()
 
         reasons: list[str] = []
         if rssi_dbm is not None and rssi_dbm <= self.thresholds.poor_rssi_dbm:
@@ -203,7 +272,7 @@ class ConnectivityReporter:
             if now - self._last_sent_at < self.min_send_interval_sec:
                 return None
             self._last_sent_at = now
-            return self._build_payload(quality, reason, rssi_dbm, packet_loss_pct, rtt_ms)
+            return self._build_payload(quality, reason, rssi_dbm, packet_loss_pct, rtt_ms, uplink_kbps, downlink_kbps)
 
         if quality == self._last_quality:
             return None
@@ -213,7 +282,7 @@ class ConnectivityReporter:
 
         self._last_quality = quality
         self._last_sent_at = now
-        return self._build_payload(quality, reason, rssi_dbm, packet_loss_pct, rtt_ms)
+        return self._build_payload(quality, reason, rssi_dbm, packet_loss_pct, rtt_ms, uplink_kbps, downlink_kbps)
 
     def _build_payload(
         self,
@@ -222,6 +291,8 @@ class ConnectivityReporter:
         rssi_dbm: int | None,
         packet_loss_pct: float | None,
         rtt_ms: int | None,
+        uplink_kbps: int | None,
+        downlink_kbps: int | None,
     ) -> dict:
         return {
             "quality": quality,
@@ -229,7 +300,7 @@ class ConnectivityReporter:
             "rssiDbm": rssi_dbm,
             "packetLossPct": packet_loss_pct,
             "rttMs": rtt_ms,
-            "uplinkKbps": None,
-            "downlinkKbps": None,
+            "uplinkKbps": uplink_kbps,
+            "downlinkKbps": downlink_kbps,
             "measuredAt": self._measured_at_factory(),
         }

--- a/nuvion_app/inference/pipeline.py
+++ b/nuvion_app/inference/pipeline.py
@@ -46,6 +46,8 @@ gi.require_version("Gst", "1.0")
 from gi.repository import Gst, GLib
 
 from nuvion_app.inference.zero_shot import ZeroShotAnomalyDetector
+from nuvion_app.inference.video_source import build_video_source_pipeline
+from nuvion_app.inference.video_source import is_truthy
 from nuvion_app.runtime.inference_mode import (
     apply_inference_runtime_defaults,
     normalize_backend,
@@ -99,6 +101,10 @@ DEVICE_PASSWORD = os.getenv("NUVION_DEVICE_PASSWORD", "password")
 
 VIDEO_SOURCE_ENV = os.getenv("NUVION_VIDEO_SOURCE", "/dev/video0")
 GST_SOURCE_OVERRIDE = os.getenv("NUVION_GST_SOURCE")
+DEMO_MODE = is_truthy(os.getenv("NUVION_DEMO_MODE", "false"))
+DEMO_VIDEO_PATH = (os.getenv("NUVION_DEMO_VIDEO_PATH", "") or "").strip()
+DEMO_LOOP = is_truthy(os.getenv("NUVION_DEMO_LOOP", "true"))
+DEMO_TAG = ((os.getenv("NUVION_DEMO_TAG", "[DEMO]") or "").strip() or "[DEMO]")
 
 RTP_REMOTE_IP_ENV = os.getenv("NUVION_RTP_REMOTE_IP", "")
 RTP_SSRC_ENV = os.getenv("NUVION_RTP_SSRC", None)
@@ -115,7 +121,7 @@ PRODUCTION_CONFIDENCE_THRESHOLD = parse_float(os.getenv("NUVION_PRODUCTION_CONFI
 ANOMALY_MIN_INTERVAL_SEC = parse_float(os.getenv("NUVION_ANOMALY_MIN_INTERVAL_SEC"), 5.0)
 PRODUCTION_DEDUP_SEC = parse_float(os.getenv("NUVION_PRODUCTION_DEDUP_SEC"), 3.0)
 
-ZERO_SHOT_ENABLED = os.getenv("NUVION_ZERO_SHOT_ENABLED", "true").lower() in ("1", "true", "yes")
+ZERO_SHOT_ENABLED = is_truthy(os.getenv("NUVION_ZERO_SHOT_ENABLED", "true"))
 ZERO_SHOT_MODEL = os.getenv("NUVION_ZERO_SHOT_MODEL", "google/siglip2-base-patch16-224")
 ZERO_SHOT_DEVICE = normalize_siglip_device(os.getenv("NUVION_ZERO_SHOT_DEVICE", "auto"), default="auto")
 ZERO_SHOT_LABELS = parse_csv(os.getenv("NUVION_ZERO_SHOT_LABELS", "normal,defect"))
@@ -123,12 +129,12 @@ ZERO_SHOT_ANOMALY_LABELS = parse_csv(os.getenv("NUVION_ZERO_SHOT_ANOMALY_LABELS"
 ZERO_SHOT_THRESHOLD = parse_float(os.getenv("NUVION_ZERO_SHOT_THRESHOLD"), 0.7)
 ZERO_SHOT_SAMPLE_SEC = parse_float(os.getenv("NUVION_ZERO_SHOT_SAMPLE_SEC"), 2.0)
 
-LOCAL_DISPLAY = os.getenv("NUVION_LOCAL_DISPLAY", "false").lower() in ("1", "true", "yes")
+LOCAL_DISPLAY = is_truthy(os.getenv("NUVION_LOCAL_DISPLAY", "false"))
 
 TRITON_THRESHOLD = parse_float(os.getenv("NUVION_TRITON_THRESHOLD"), 0.7)
 ZSAD_BACKEND = normalize_backend(os.getenv("NUVION_ZSAD_BACKEND", "triton"), default="triton")
 
-CLIP_ENABLED = os.getenv("NUVION_CLIP_ENABLED", "true").lower() in ("1", "true", "yes")
+CLIP_ENABLED = is_truthy(os.getenv("NUVION_CLIP_ENABLED", "true"))
 CLIP_PRE_SEC = parse_float(os.getenv("NUVION_CLIP_PRE_SEC"), 5.0)
 CLIP_POST_SEC = parse_float(os.getenv("NUVION_CLIP_POST_SEC"), 5.0)
 CLIP_SEGMENT_SEC = parse_float(os.getenv("NUVION_CLIP_SEGMENT_SEC"), 1.0)
@@ -141,7 +147,7 @@ LINE_ID = parse_int(os.getenv("NUVION_LINE_ID"))
 PROCESS_ID = parse_int(os.getenv("NUVION_PROCESS_ID"))
 DEVICE_STATE_INTERVAL_SEC = parse_float(os.getenv("NUVION_DEVICE_STATE_INTERVAL_SEC"), 30.0)
 
-CONNECTIVITY_ENABLED = os.getenv("NUVION_CONNECTIVITY_ENABLED", "true").lower() in ("1", "true", "yes")
+CONNECTIVITY_ENABLED = is_truthy(os.getenv("NUVION_CONNECTIVITY_ENABLED", "true"))
 CONNECTIVITY_INTERVAL_SEC = parse_float(os.getenv("NUVION_CONNECTIVITY_INTERVAL_SEC"), 10.0)
 CONNECTIVITY_MIN_SEND_INTERVAL_SEC = parse_float(os.getenv("NUVION_CONNECTIVITY_MIN_SEND_INTERVAL_SEC"), 30.0)
 CONNECTIVITY_POOR_RSSI_DBM = parse_int_with_default(os.getenv("NUVION_CONNECTIVITY_POOR_RSSI_DBM"), -80)
@@ -976,6 +982,8 @@ class NuvionEventState:
         self.last_sent_status = None
         self.last_sent_at = 0.0
         self.clip_enabled = CLIP_ENABLED
+        self.demo_mode = DEMO_MODE
+        self.demo_tag = DEMO_TAG
         self.clip_in_progress = False
         self.clip_last_started = 0.0
         self.clip_lock = threading.Lock()
@@ -1045,10 +1053,11 @@ class NuvionEventState:
             if clip_object:
                 clip_status = "UPLOADING"
 
+        tagged_message = self._apply_demo_tag(message)
         payload = {
             "anomalyType": anomaly_type,
             "anomalyStatus": status,
-            "message": message,
+            "message": tagged_message,
             "severity": severity,
             "lineId": LINE_ID,
             "processId": PROCESS_ID,
@@ -1062,9 +1071,16 @@ class NuvionEventState:
         self.last_sent_status = status
         self.last_sent_at = now
         if status_changed:
-            log.info("[ZSAD] Sent %s status (change): %s", status, message)
+            log.info("[ZSAD] Sent %s status (change): %s", status, tagged_message)
         else:
-            log.info("[ZSAD] Sent %s status (repeat): %s", status, message)
+            log.info("[ZSAD] Sent %s status (repeat): %s", status, tagged_message)
+
+    def _apply_demo_tag(self, message: str) -> str:
+        if not self.demo_mode:
+            return message
+        if message.lstrip().startswith(self.demo_tag):
+            return message
+        return f"{self.demo_tag} {message}"
 
     def start_clip_upload(self) -> str | None:
         if not self.clip_enabled or not CLIP_ENABLED:
@@ -1273,39 +1289,6 @@ class NuvionEventState:
                         self.last_production_at = now
                         self.report_production(1)
 
-
-def build_source_pipeline(video_source: str, width: int, height: int, fps: int) -> str:
-    if GST_SOURCE_OVERRIDE:
-        return GST_SOURCE_OVERRIDE
-
-    if not video_source or video_source == "auto":
-        video_source = "avf" if sys.platform == "darwin" else "/dev/video0"
-
-    if video_source.startswith("/dev/video"):
-        if sys.platform == "darwin":
-            source = "avfvideosrc"
-        else:
-            source = f"v4l2src device={video_source}"
-    elif video_source.lower() in {"rpi", "libcamera"}:
-        source = "libcamerasrc"
-    elif video_source.lower().startswith(("avf", "avfoundation", "mac")):
-        device_index = None
-        if ":" in video_source:
-            _, maybe_index = video_source.split(":", 1)
-            if maybe_index.isdigit():
-                device_index = int(maybe_index)
-        source = f"avfvideosrc device-index={device_index}" if device_index is not None else "avfvideosrc"
-    else:
-        source = "autovideosrc"
-
-    return (
-        f"{source} ! "
-        f"video/x-raw,width={width},height={height},framerate={fps}/1 ! "
-        "videoconvert ! "
-        "video/x-raw,format=RGB"
-    )
-
-
 def on_new_sample(appsink, user_data: NuvionEventState):
     sample = appsink.emit("pull-sample")
     if sample is None:
@@ -1341,6 +1324,8 @@ class GStreamerInferenceApp:
         self.video_height = 480
         self.frame_rate = 30
         self.video_source = video_source
+        self.demo_mode = DEMO_MODE
+        self.demo_loop = DEMO_LOOP
         self.rtp_ssrc = get_rtp_ssrc()
         self.overlay = None
         self.user_data = NuvionEventState(self.update_overlay_text)
@@ -1355,7 +1340,15 @@ class GStreamerInferenceApp:
 
     def create_pipeline(self):
         Gst.init(None)
-        source_pipeline = build_source_pipeline(self.video_source, self.video_width, self.video_height, self.frame_rate)
+        source_pipeline = build_video_source_pipeline(
+            self.video_source,
+            self.video_width,
+            self.video_height,
+            self.frame_rate,
+            gst_source_override=GST_SOURCE_OVERRIDE,
+            demo_mode=self.demo_mode,
+            demo_video_path=DEMO_VIDEO_PATH,
+        )
 
         overlay_pipeline = (
             "videoconvert ! "
@@ -1451,6 +1444,16 @@ class GStreamerInferenceApp:
     def bus_call(self, bus, message, loop):
         msg_type = message.type
         if msg_type == Gst.MessageType.EOS:
+            if self.demo_mode and self.demo_loop and self.pipeline:
+                ok = self.pipeline.seek_simple(
+                    Gst.Format.TIME,
+                    Gst.SeekFlags.FLUSH | Gst.SeekFlags.KEY_UNIT,
+                    0,
+                )
+                if ok:
+                    log.info("[DEMO] End-of-stream reached. Restarting demo video.")
+                    return True
+                log.error("[DEMO] Failed to seek demo video on EOS.")
             log.info("End-of-stream")
             self.shutdown()
         elif msg_type == Gst.MessageType.ERROR:
@@ -1485,11 +1488,12 @@ class GStreamerInferenceApp:
 
     def _default_overlay_text(self) -> str:
         backend = getattr(self.user_data, "backend", "none")
+        prefix = "DEMO | " if self.demo_mode else ""
         if backend == "triton":
-            return "ZSAD TRITON ON"
+            return f"{prefix}ZSAD TRITON ON"
         if backend == "siglip":
-            return "ZSAD ON"
-        return "ZSAD OFF"
+            return f"{prefix}ZSAD ON"
+        return f"{prefix}ZSAD OFF"
 
     def run(self):
         def _start():

--- a/nuvion_app/inference/video_source.py
+++ b/nuvion_app/inference/video_source.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+DEFAULT_DEMO_VIDEO_FILENAME = "exhibition-demo.webm"
+DEFAULT_DEMO_VIDEO_PATHS = (
+    Path("/var/lib/nuv-agent/demo") / DEFAULT_DEMO_VIDEO_FILENAME,
+    Path("/opt/homebrew/var/nuv-agent/demo") / DEFAULT_DEMO_VIDEO_FILENAME,
+    Path("/usr/local/var/nuv-agent/demo") / DEFAULT_DEMO_VIDEO_FILENAME,
+)
+
+
+def is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _validate_path(path: Path) -> Path:
+    if not path.exists():
+        raise ValueError(f"Demo video path does not exist: {path}")
+    if not path.is_file():
+        raise ValueError(f"Demo video path is not a file: {path}")
+    if not os.access(path, os.R_OK):
+        raise ValueError(f"Demo video path is not readable: {path}")
+    return path.resolve()
+
+
+def _fallback_paths_from_env() -> tuple[Path, ...]:
+    raw = (os.getenv("NUVION_DEMO_VIDEO_FALLBACK_PATHS", "") or "").strip()
+    if not raw:
+        return ()
+    paths: list[Path] = []
+    for item in raw.split(","):
+        value = item.strip()
+        if not value:
+            continue
+        paths.append(Path(value).expanduser())
+    return tuple(paths)
+
+
+def resolve_demo_video_path(demo_video_path: str | None) -> Path:
+    raw = (demo_video_path or "").strip()
+    if raw:
+        return _validate_path(Path(raw).expanduser())
+
+    for path in (*_fallback_paths_from_env(), *DEFAULT_DEMO_VIDEO_PATHS):
+        if not path.exists():
+            continue
+        try:
+            return _validate_path(path)
+        except ValueError:
+            continue
+
+    example_path = DEFAULT_DEMO_VIDEO_PATHS[0] if DEFAULT_DEMO_VIDEO_PATHS else Path("/var/lib/nuv-agent/demo/exhibition-demo.webm")
+    raise ValueError(
+        "NUVION_DEMO_VIDEO_PATH is required when NUVION_DEMO_MODE=true. "
+        f"No fallback demo video found (expected e.g. {example_path})."
+    )
+
+
+def build_video_source_pipeline(
+    video_source: str,
+    width: int,
+    height: int,
+    fps: int,
+    *,
+    gst_source_override: str | None = None,
+    demo_mode: bool = False,
+    demo_video_path: str | None = None,
+    platform_name: str | None = None,
+) -> str:
+    if gst_source_override and gst_source_override.strip():
+        return gst_source_override.strip()
+
+    current_platform = platform_name or sys.platform
+
+    if demo_mode:
+        demo_path = resolve_demo_video_path(demo_video_path)
+        uri = demo_path.as_uri()
+        return (
+            f'uridecodebin uri="{uri}" ! '
+            "queue ! "
+            "videoconvert ! "
+            "videoscale ! "
+            "videorate ! "
+            f"video/x-raw,width={width},height={height},framerate={fps}/1 ! "
+            "videoconvert ! "
+            "video/x-raw,format=RGB"
+        )
+
+    resolved_source = video_source
+    if not resolved_source or resolved_source == "auto":
+        resolved_source = "avf" if current_platform == "darwin" else "/dev/video0"
+
+    if resolved_source.startswith("/dev/video"):
+        if current_platform == "darwin":
+            source = "avfvideosrc"
+        else:
+            source = f"v4l2src device={resolved_source}"
+    elif resolved_source.lower() in {"rpi", "libcamera"}:
+        source = "libcamerasrc"
+    elif resolved_source.lower().startswith(("avf", "avfoundation", "mac")):
+        device_index = None
+        if ":" in resolved_source:
+            _, maybe_index = resolved_source.split(":", 1)
+            if maybe_index.isdigit():
+                device_index = int(maybe_index)
+        source = f"avfvideosrc device-index={device_index}" if device_index is not None else "avfvideosrc"
+    else:
+        source = "autovideosrc"
+
+    return (
+        f"{source} ! "
+        f"video/x-raw,width={width},height={height},framerate={fps}/1 ! "
+        "videoconvert ! "
+        "video/x-raw,format=RGB"
+    )

--- a/nuvion_app/runtime/config_guard.py
+++ b/nuvion_app/runtime/config_guard.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from nuvion_app.config import REQUIRED_KEYS, load_template, read_env, write_env
+from nuvion_app.inference.video_source import resolve_demo_video_path
 from nuvion_app.model_store import DEFAULT_MODEL_PROFILE, DEFAULT_MODEL_SOURCE
 from nuvion_app.runtime.inference_mode import normalize_backend, normalize_siglip_device
 
@@ -14,6 +15,12 @@ _VALID_MODEL_SOURCES = {"server", "gcs"}
 _VALID_MODEL_PROFILES = {"runtime", "light", "full"}
 _VALID_TRITON_INPUT_FORMATS = {"NCHW", "NHWC"}
 _SECRET_MARKERS = ("PASSWORD", "TOKEN", "SECRET")
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 @dataclass
@@ -161,6 +168,12 @@ def _validate_values(values: Dict[str, str]) -> tuple[List[ConfigIssue], List[Co
 
     if source not in _VALID_MODEL_SOURCES:
         errors.append(ConfigIssue(key="NUVION_MODEL_SOURCE", message="지원하지 않는 모델 source입니다. (server|gcs)"))
+
+    if _is_truthy(values.get("NUVION_DEMO_MODE", "false")):
+        try:
+            resolve_demo_video_path(values.get("NUVION_DEMO_VIDEO_PATH"))
+        except ValueError as exc:
+            errors.append(ConfigIssue(key="NUVION_DEMO_VIDEO_PATH", message=str(exc)))
 
     if backend == "triton":
         triton_url = (values.get("NUVION_TRITON_URL", "") or "").strip()

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -14,6 +14,10 @@ Recommended service env vars (already in the formula):
 - `GI_TYPELIB_PATH`
 - `GST_PLUGIN_PATH`
 
+Demo sample video:
+- Formula installs a default demo asset to `$(brew --prefix)/var/nuv-agent/demo/exhibition-demo.webm`.
+- Use with `nuv-agent run --demo --demo-video <path>`.
+
 ## Debian/Ubuntu (.deb)
 Build a package on the target architecture (e.g., Jetson ARM64):
 ```bash
@@ -27,6 +31,8 @@ This script:
 - Installs the systemd unit.
 - Creates `/etc/nuv-agent/agent.env` if missing.
 - Installs optional extras for runtime bootstrap (`zsad,triton`).
+- Best-effort downloads a default demo video to `/var/lib/nuv-agent/demo/exhibition-demo.webm`.
+- Override source URL at install time with `NUVION_DEMO_VIDEO_URL=<direct-video-url>`.
 
 Python requirement: 3.10+
 

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -23,7 +23,7 @@ Section: utils
 Priority: optional
 Architecture: ${ARCH}
 Maintainer: Nuvion <ops@nuvion.ai>
-Depends: python3 (>= 3.10), python3-venv, python3-pip, python3-gi, ffmpeg, gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, gstreamer1.0-libav, gir1.2-gstreamer-1.0, gir1.2-gst-plugins-base-1.0
+Depends: python3 (>= 3.10), python3-venv, python3-pip, python3-gi, curl | wget, ffmpeg, gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly, gstreamer1.0-libav, gir1.2-gstreamer-1.0, gir1.2-gst-plugins-base-1.0
 Description: Nuvion on-device agent
 CONTROL
 

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -18,6 +18,36 @@ if [ ! -f /etc/nuv-agent/agent.env ]; then
   cp /opt/nuv-agent/share/agent.env.example /etc/nuv-agent/agent.env
 fi
 
+DEMO_DIR="/var/lib/nuv-agent/demo"
+DEMO_FILE="exhibition-demo.webm"
+DEMO_PATH="${DEMO_DIR}/${DEMO_FILE}"
+DEMO_URL="${NUVION_DEMO_VIDEO_URL:-https://upload.wikimedia.org/wikipedia/commons/a/af/Gigaset_Smartphone_Production_IV_Quality_Inspection.webm}"
+
+install -d -m 0775 -o root -g nuvion "$DEMO_DIR"
+
+if [ ! -s "$DEMO_PATH" ]; then
+  tmp_file="$(mktemp /tmp/nuv-agent-demo.XXXXXX)"
+  downloaded="false"
+  if command -v curl >/dev/null 2>&1; then
+    if curl -fsSL --retry 3 --connect-timeout 10 --max-time 180 "$DEMO_URL" -o "$tmp_file"; then
+      downloaded="true"
+    fi
+  elif command -v wget >/dev/null 2>&1; then
+    if wget -q --tries=3 --timeout=10 -O "$tmp_file" "$DEMO_URL"; then
+      downloaded="true"
+    fi
+  fi
+
+  if [ "$downloaded" = "true" ] && [ -s "$tmp_file" ]; then
+    mv "$tmp_file" "$DEMO_PATH"
+    chown root:nuvion "$DEMO_PATH"
+    chmod 0644 "$DEMO_PATH"
+  else
+    rm -f "$tmp_file"
+    echo "[postinst] warning: failed to download demo video from ${DEMO_URL}" >&2
+  fi
+fi
+
 chown root:nuvion /etc/nuv-agent/agent.env
 chmod 0660 /etc/nuv-agent/agent.env
 
@@ -36,6 +66,16 @@ if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
 fi
 
 if command -v python3 >/dev/null 2>&1; then
+  if [ -f "$DEMO_PATH" ]; then
+    if grep -q '^NUVION_DEMO_VIDEO_PATH=' /etc/nuv-agent/agent.env; then
+      if grep -q '^NUVION_DEMO_VIDEO_PATH=$' /etc/nuv-agent/agent.env; then
+        sed -i "s|^NUVION_DEMO_VIDEO_PATH=$|NUVION_DEMO_VIDEO_PATH=${DEMO_PATH}|" /etc/nuv-agent/agent.env
+      fi
+    else
+      echo "NUVION_DEMO_VIDEO_PATH=${DEMO_PATH}" >> /etc/nuv-agent/agent.env
+    fi
+  fi
+
   python3 -m venv --clear --system-site-packages /opt/nuv-agent/venv
   /opt/nuv-agent/venv/bin/pip install --no-cache-dir --upgrade pip >/dev/null
   /opt/nuv-agent/venv/bin/pip install --no-cache-dir --upgrade "/opt/nuv-agent/src[zsad,triton]" >/dev/null

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -104,6 +104,11 @@ class NuvAgent < Formula
     sha256 "bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
   end
 
+  resource "demo-video" do
+    url "https://upload.wikimedia.org/wikipedia/commons/a/af/Gigaset_Smartphone_Production_IV_Quality_Inspection.webm"
+    sha256 "9f1df90978a735f1836cf36777075e959bef20ba63b4546fb0feec38fb731dec"
+  end
+
   resource "anyio" do
     url "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl"
     sha256 "d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c"
@@ -299,6 +304,7 @@ class NuvAgent < Formula
     venv = virtualenv_create(libexec, python, system_site_packages: true)
 
     resources.each do |r|
+      next if r.name == "demo-video"
       r.stage do
         wheel = Dir["*.whl"].first
         target = wheel ? Pathname.pwd/wheel : Pathname.pwd
@@ -310,6 +316,15 @@ class NuvAgent < Formula
     system python, "-m", "pip", "--python=#{venv.root}/bin/python", "install",
            "--no-deps", "--ignore-installed", "--no-compile", buildpath
     (etc/"nuv-agent").mkpath
+    demo_dir = var/"nuv-agent/demo"
+    demo_dir.mkpath
+
+    resource("demo-video").stage do
+      demo_src = Dir["*.webm"].first
+      if demo_src
+        cp demo_src, demo_dir/"exhibition-demo.webm"
+      end
+    end
 
     env = {
       "DYLD_LIBRARY_PATH" => "#{HOMEBREW_PREFIX}/lib",
@@ -330,6 +345,11 @@ class NuvAgent < Formula
       1) install Homebrew (if missing),
       2) install docker + colima (if missing),
       3) start a local Triton container when NUVION_ZSAD_BACKEND=triton.
+
+      Demo sample video installed:
+        #{var}/nuv-agent/demo/exhibition-demo.webm
+      To run demo mode:
+        nuv-agent run --demo --demo-video #{var}/nuv-agent/demo/exhibition-demo.webm
 
       If Docker Desktop is already running, it is used first. Colima is only a fallback.
     EOS

--- a/tests/inference/test_connectivity.py
+++ b/tests/inference/test_connectivity.py
@@ -4,9 +4,12 @@ import unittest
 
 from nuvion_app.inference.connectivity import ConnectivityReporter
 from nuvion_app.inference.connectivity import ConnectivityThresholds
+from nuvion_app.inference.connectivity import collect_link_bitrate_kbps
 from nuvion_app.inference.connectivity import collect_ping_metrics
 from nuvion_app.inference.connectivity import collect_rssi_dbm
+from nuvion_app.inference.connectivity import parse_airport_output_for_bitrate_kbps
 from nuvion_app.inference.connectivity import parse_airport_output_for_rssi
+from nuvion_app.inference.connectivity import parse_iw_link_output_for_bitrate_kbps
 from nuvion_app.inference.connectivity import parse_iw_link_output_for_rssi
 from nuvion_app.inference.connectivity import parse_ping_output
 
@@ -26,6 +29,23 @@ class ConnectivityParserTest(unittest.TestCase):
             \ttx bitrate: 54.0 MBit/s
         """
         self.assertEqual(parse_iw_link_output_for_rssi(output), -78)
+
+    def test_parse_airport_output_for_bitrate_kbps(self) -> None:
+        output = """
+            agrCtlRSSI: -67
+            lastTxRate: 351
+            maxRate: 780
+        """
+        self.assertEqual(parse_airport_output_for_bitrate_kbps(output), (351000, 780000))
+
+    def test_parse_iw_link_output_for_bitrate_kbps(self) -> None:
+        output = """
+            Connected to aa:bb:cc:dd:ee:ff (on wlan0)
+            \tsignal: -78 dBm
+            \ttx bitrate: 54.0 MBit/s
+            \trx bitrate: 18.5 MBit/s
+        """
+        self.assertEqual(parse_iw_link_output_for_bitrate_kbps(output), (54000, 18500))
 
     def test_parse_ping_output_linux_and_macos(self) -> None:
         linux_output = """
@@ -68,6 +88,26 @@ class ConnectivityParserTest(unittest.TestCase):
 
         self.assertEqual(collect_ping_metrics("api.example.com", platform_name="linux", run_command_fn=fake_run), (0.0, 15))
 
+    def test_collect_link_bitrate_for_darwin(self) -> None:
+        def fake_run(cmd: list[str], timeout: float) -> str | None:
+            _ = timeout
+            if cmd[-1] == "-I":
+                return "lastTxRate: 433\nmaxRate: 866"
+            return None
+
+        self.assertEqual(collect_link_bitrate_kbps(platform_name="darwin", run_command_fn=fake_run), (433000, 866000))
+
+    def test_collect_link_bitrate_for_linux(self) -> None:
+        def fake_run(cmd: list[str], timeout: float) -> str | None:
+            _ = timeout
+            if cmd == ["iw", "dev"]:
+                return "phy#0\n\tInterface wlan0\n"
+            if cmd == ["iw", "dev", "wlan0", "link"]:
+                return "Connected\n\ttx bitrate: 65.0 MBit/s\n\trx bitrate: 32.5 MBit/s\n"
+            return None
+
+        self.assertEqual(collect_link_bitrate_kbps(platform_name="linux", run_command_fn=fake_run), (65000, 32500))
+
 
 class ConnectivityReporterTest(unittest.TestCase):
     def test_reporter_sends_only_transitions(self) -> None:
@@ -90,6 +130,9 @@ class ConnectivityReporterTest(unittest.TestCase):
             idx["i"] += 1
             return sample["loss"], sample["rtt"]
 
+        def bitrate_collector() -> tuple[int | None, int | None]:
+            return 12000, 18000
+
         ticks = iter([0.0, 2.0, 4.0, 6.0, 8.0])
 
         reporter = ConnectivityReporter(
@@ -98,6 +141,7 @@ class ConnectivityReporterTest(unittest.TestCase):
             min_send_interval_sec=1.0,
             rssi_collector=rssi_collector,
             ping_collector=ping_collector,
+            bitrate_collector=bitrate_collector,
             clock=lambda: next(ticks),
             measured_at_factory=lambda: "2026-03-04T07:42:10Z",
         )
@@ -111,9 +155,13 @@ class ConnectivityReporterTest(unittest.TestCase):
         self.assertIsNotNone(second)
         self.assertEqual(second["quality"], "POOR")
         self.assertIn("wifi_rssi_low", second["reason"])
+        self.assertEqual(second["uplinkKbps"], 12000)
+        self.assertEqual(second["downlinkKbps"], 18000)
         self.assertIsNone(third)  # Repeated POOR state is ignored.
         self.assertIsNotNone(fourth)
         self.assertEqual(fourth["quality"], "GOOD")
+        self.assertEqual(fourth["uplinkKbps"], 12000)
+        self.assertEqual(fourth["downlinkKbps"], 18000)
 
 
 if __name__ == "__main__":

--- a/tests/inference/test_video_source.py
+++ b/tests/inference/test_video_source.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from nuvion_app.inference.video_source import build_video_source_pipeline
+from nuvion_app.inference.video_source import resolve_demo_video_path
+
+
+class VideoSourceTest(unittest.TestCase):
+    def test_build_camera_source_linux(self) -> None:
+        pipeline = build_video_source_pipeline(
+            "/dev/video0",
+            640,
+            480,
+            30,
+            platform_name="linux",
+        )
+        self.assertIn("v4l2src device=/dev/video0", pipeline)
+        self.assertIn("video/x-raw,format=RGB", pipeline)
+
+    def test_build_camera_source_macos_auto(self) -> None:
+        pipeline = build_video_source_pipeline(
+            "auto",
+            640,
+            480,
+            30,
+            platform_name="darwin",
+        )
+        self.assertIn("avfvideosrc", pipeline)
+
+    def test_demo_mode_accepts_valid_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            demo_file = Path(tmp) / "demo.mp4"
+            demo_file.write_bytes(b"fake")
+
+            pipeline = build_video_source_pipeline(
+                "/dev/video0",
+                640,
+                480,
+                30,
+                demo_mode=True,
+                demo_video_path=str(demo_file),
+                platform_name="linux",
+            )
+
+            self.assertIn("uridecodebin", pipeline)
+            self.assertIn(demo_file.resolve().as_uri(), pipeline)
+
+    def test_demo_mode_requires_path(self) -> None:
+        with mock.patch("nuvion_app.inference.video_source.DEFAULT_DEMO_VIDEO_PATHS", tuple()):
+            with mock.patch.dict("os.environ", {"NUVION_DEMO_VIDEO_FALLBACK_PATHS": ""}, clear=False):
+                with self.assertRaises(ValueError):
+                    build_video_source_pipeline(
+                        "/dev/video0",
+                        640,
+                        480,
+                        30,
+                        demo_mode=True,
+                        demo_video_path="",
+                        platform_name="linux",
+                    )
+
+    def test_gst_override_takes_priority(self) -> None:
+        pipeline = build_video_source_pipeline(
+            "/dev/video0",
+            640,
+            480,
+            30,
+            gst_source_override="videotestsrc pattern=smpte",
+            demo_mode=True,
+            demo_video_path="/tmp/demo.mp4",
+            platform_name="linux",
+        )
+        self.assertEqual(pipeline, "videotestsrc pattern=smpte")
+
+    def test_demo_mode_uses_fallback_path_when_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            demo_file = Path(tmp) / "demo.webm"
+            demo_file.write_bytes(b"fake")
+            with mock.patch.dict(
+                "os.environ",
+                {"NUVION_DEMO_VIDEO_FALLBACK_PATHS": str(demo_file)},
+                clear=False,
+            ):
+                resolved = resolve_demo_video_path("")
+            self.assertEqual(resolved, demo_file.resolve())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_cli_demo_mode.py
+++ b/tests/runtime/test_cli_demo_mode.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from nuvion_app import cli
+
+
+class CliDemoModeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        for key in ("NUVION_DEMO_MODE", "NUVION_DEMO_VIDEO_PATH"):
+            os.environ.pop(key, None)
+
+    def _run_cli(self, argv: list[str]) -> None:
+        fake_inference_main = types.ModuleType("nuvion_app.inference.main")
+        fake_inference_main.main = mock.Mock()
+
+        with mock.patch.dict(sys.modules, {"nuvion_app.inference.main": fake_inference_main}):
+            with mock.patch.object(sys, "argv", argv):
+                with mock.patch("nuvion_app.cli.resolve_config_path", return_value=Path("/tmp/agent.env")):
+                    with mock.patch("nuvion_app.cli.load_env", return_value=Path("/tmp/agent.env")):
+                        with mock.patch("nuvion_app.cli.ensure_runtime_config") as ensure_runtime_config:
+                            ensure_runtime_config.return_value = mock.Mock(ok=True)
+                            cli.main()
+
+        fake_inference_main.main.assert_called_once()
+
+    def test_run_demo_sets_demo_mode_env(self) -> None:
+        self._run_cli(["nuv-agent", "run", "--demo"])
+        self.assertEqual(os.getenv("NUVION_DEMO_MODE"), "true")
+
+    def test_run_demo_video_overrides_env(self) -> None:
+        with mock.patch.dict(os.environ, {"NUVION_DEMO_VIDEO_PATH": "/tmp/old.mp4"}, clear=False):
+            self._run_cli(["nuv-agent", "run", "--demo", "--demo-video", "/tmp/new.mp4"])
+            self.assertEqual(os.getenv("NUVION_DEMO_VIDEO_PATH"), "/tmp/new.mp4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_config_guard.py
+++ b/tests/runtime/test_config_guard.py
@@ -74,6 +74,73 @@ class ConfigGuardTest(unittest.TestCase):
                 report = guard_config(config_path=config_path, apply_fixes=False)
             self.assertIn("NUVION_TRITON_INPUT", report.env_overrides)
 
+    def test_guard_requires_demo_video_path_when_demo_enabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "agent.env"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "NUVION_SERVER_BASE_URL=https://api.example.com",
+                        "NUVION_DEVICE_USERNAME=device-1",
+                        "NUVION_DEVICE_PASSWORD=secret",
+                        "NUVION_RTP_REMOTE_IP=1.2.3.4",
+                        "NUVION_DEMO_MODE=true",
+                        "NUVION_DEMO_VIDEO_PATH=",
+                        "",
+                    ]
+                )
+            )
+            with mock.patch("nuvion_app.inference.video_source.DEFAULT_DEMO_VIDEO_PATHS", tuple()):
+                with mock.patch.dict(os.environ, {"NUVION_DEMO_VIDEO_FALLBACK_PATHS": ""}, clear=False):
+                    report = guard_config(config_path=config_path, apply_fixes=True)
+            self.assertFalse(report.ok)
+            self.assertTrue(any(issue.key == "NUVION_DEMO_VIDEO_PATH" for issue in report.errors))
+
+    def test_guard_accepts_demo_video_path_when_demo_enabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            demo_file = Path(tmp) / "demo.mp4"
+            demo_file.write_bytes(b"fake")
+
+            config_path = Path(tmp) / "agent.env"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "NUVION_SERVER_BASE_URL=https://api.example.com",
+                        "NUVION_DEVICE_USERNAME=device-1",
+                        "NUVION_DEVICE_PASSWORD=secret",
+                        "NUVION_RTP_REMOTE_IP=1.2.3.4",
+                        "NUVION_DEMO_MODE=true",
+                        f"NUVION_DEMO_VIDEO_PATH={demo_file}",
+                        "",
+                    ]
+                )
+            )
+            report = guard_config(config_path=config_path, apply_fixes=True)
+            self.assertTrue(report.ok)
+
+    def test_guard_accepts_fallback_demo_video_path_when_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            demo_file = Path(tmp) / "demo.webm"
+            demo_file.write_bytes(b"fake")
+
+            config_path = Path(tmp) / "agent.env"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "NUVION_SERVER_BASE_URL=https://api.example.com",
+                        "NUVION_DEVICE_USERNAME=device-1",
+                        "NUVION_DEVICE_PASSWORD=secret",
+                        "NUVION_RTP_REMOTE_IP=1.2.3.4",
+                        "NUVION_DEMO_MODE=true",
+                        "NUVION_DEMO_VIDEO_PATH=",
+                        "",
+                    ]
+                )
+            )
+            with mock.patch.dict(os.environ, {"NUVION_DEMO_VIDEO_FALLBACK_PATHS": str(demo_file)}, clear=False):
+                report = guard_config(config_path=config_path, apply_fixes=True)
+            self.assertTrue(report.ok)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 요약
- `nuv-agent run --demo` / `--demo-video` 추가
- 데모 입력 소스 분리(`video_source.py`) 및 데모 영상 경로 fail-fast 검증
- 데모 모드 EOS 자동 루프 재생, anomaly 메시지 `[DEMO]` 태깅, 오버레이 `DEMO | ...` 표시
- deb/homebrew 설치 시 기본 데모 영상 자동 배포(경로 fallback 포함)
- Debian postinst에서 `NUVION_DEMO_VIDEO_URL`로 설치 시점 데모 영상 URL override 지원
- 기본 샘플 영상을 품질검사 클로즈업 소스로 교체
  - `Gigaset Smartphone Production IV Quality Inspection.webm`
- connectivity payload에 `uplinkKbps/downlinkKbps` 필드 추가
- 관련 문서/테스트 보강

## 주요 파일
- `nuvion_app/cli.py`
- `nuvion_app/inference/video_source.py` (new)
- `nuvion_app/inference/pipeline.py`
- `nuvion_app/runtime/config_guard.py`
- `nuvion_app/config.py`
- `packaging/deb/postinst`
- `packaging/homebrew/nuv-agent.rb`
- `README.md`, `packaging/README.md`
- `tests/inference/test_video_source.py` (new)
- `tests/runtime/test_cli_demo_mode.py` (new)

## 테스트
```bash
python3 -m unittest tests.inference.test_video_source tests.runtime.test_config_guard tests.runtime.test_cli_demo_mode tests.inference.test_connectivity
```
- 결과: `Ran 25 tests ... OK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 데모 모드 지원 추가 - 라이브 카메라 대신 미리 녹화된 영상으로 시연 가능
  * CLI에 `--demo` 및 `--demo-video` 플래그 추가로 명령줄에서 데모 모드 제어
  * 연결 상태 보고에 업링크/다운링크 비트레이트 정보 포함
  * 패키지에 데모 영상 사전 설치 (Homebrew, Debian/Ubuntu)

* **설정 옵션**
  * 데모 영상 경로, 반복 재생, 태그 지정을 위한 환경 변수 추가
  * 연결성 모니터링 관련 새로운 설정 옵션 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->