### PR TITLE
fix(agent): demo EOS 루프 크리티컬 로그 및 x264 경고 완화

### DIFF
--- a/nuvion_app/inference/pipeline.py
+++ b/nuvion_app/inference/pipeline.py
@@ -36,7 +36,6 @@ warnings.filterwarnings(
     "ignore",
     message=r".*invalid escape sequence.*",
     category=SyntaxWarning,
-    module=r"stomper\.stompbuffer",
 )
 import stomper
 
@@ -1367,7 +1366,7 @@ class GStreamerInferenceApp:
             "tune=zerolatency "
             "speed-preset=faster "
             "bitrate=8000 "
-            "vbv-buf-capacity=12000 "
+            "vbv-buf-capacity=10000 "
             "key-int-max=30 "
             "bframes=0 "
             "threads=4 "
@@ -1445,15 +1444,15 @@ class GStreamerInferenceApp:
         msg_type = message.type
         if msg_type == Gst.MessageType.EOS:
             if self.demo_mode and self.demo_loop and self.pipeline:
-                ok = self.pipeline.seek_simple(
-                    Gst.Format.TIME,
-                    Gst.SeekFlags.FLUSH | Gst.SeekFlags.KEY_UNIT,
-                    0,
-                )
-                if ok:
-                    log.info("[DEMO] End-of-stream reached. Restarting demo video.")
+                # 일부 조합(uridecodebin + splitmuxsink)에서 seek 기반 루프는
+                # segment format assertion을 유발할 수 있어 상태 전환으로 재시작한다.
+                self.pipeline.set_state(Gst.State.READY)
+                restart_result = self.pipeline.set_state(Gst.State.PLAYING)
+                if restart_result != Gst.StateChangeReturn.FAILURE:
+                    self.update_overlay_text(self._default_overlay_text())
+                    log.info("[DEMO] End-of-stream reached. Restarted demo video.")
                     return True
-                log.error("[DEMO] Failed to seek demo video on EOS.")
+                log.error("[DEMO] Failed to restart demo video on EOS.")
             log.info("End-of-stream")
             self.shutdown()
         elif msg_type == Gst.MessageType.ERROR:


### PR DESCRIPTION
## 요약
- 데모 모드 EOS 루프에서 `seek_simple(TIME)` 대신 `READY -> PLAYING` 재시작으로 변경
- `uridecodebin + splitmuxsink` 조합에서 반복되던 `gst_segment_do_seek` assertion 로그 완화
- x264 `vbv-buf-capacity`를 `12000 -> 10000`으로 조정해 property out-of-range 경고 제거
- Python 3.14의 `stomper` invalid escape `SyntaxWarning` 필터 범위를 확장

## 변경 파일
- `nuvion_app/inference/pipeline.py`

## 검증
```bash
python3 -m unittest tests.inference.test_video_source tests.runtime.test_config_guard tests.runtime.test_cli_demo_mode tests.inference.test_connectivity
```
- 결과: `Ran 25 tests ... OK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 데모 재시작 동작 개선 및 안정성 강화

* **최적화**
  * 인코더 설정 조정을 통한 성능 최적화
  * 내부 리소스 관리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->