### PR TITLE
feat(packaging): add install ascii banner

### DIFF
--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.48}"
+VERSION="${VERSION:-0.1.49}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+print_nuv_agent_banner() {
+  printf '%s\n' \
+' _   _ _   ___      _    ____ _____ _   _ _____' \
+'| \ | | | | \ \    / /  / \  / ___| ____| \ | |_   _|' \
+'|  \| | | | |\ \  / /  / _ \| |  _|  _| |  \| | | |' \
+'| |\  | |_| | \ \/ /  / ___ \ |_| | |___| |\  | | |' \
+'|_| \_|\___/   \__/  /_/   \_\____|_____|_| \_| |_|'
+}
+
 if ! id -u nuvion >/dev/null 2>&1; then
   useradd --system --no-create-home --shell /usr/sbin/nologin nuvion
 fi
@@ -84,3 +93,8 @@ fi
 
 systemctl daemon-reload || true
 systemctl enable --now nuv-agent.service || true
+
+echo
+print_nuv_agent_banner
+echo
+echo "nuv-agent installed. Run: nuv-agent setup"

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.48"
+  version "0.1.49"
   license "Proprietary"
 
   depends_on "python@3.14"
@@ -341,7 +341,17 @@ class NuvAgent < Formula
   end
 
   def caveats
+    art = <<~'ART'
+       _   _ _   ___      _    ____ _____ _   _ _____
+      | \ | | | | \ \    / /  / \  / ___| ____| \ | |_   _|
+      |  \| | | | |\ \  / /  / _ \| |  _|  _| |  \| | | |
+      | |\  | |_| | \ \/ /  / ___ \ |_| | |___| |\  | | |
+      |_| \_|\___/   \__/  /_/   \_\____|_____|_| \_| |_|
+    ART
+
     <<~EOS
+      #{art}
+
       Runtime bootstrap is enabled by default.
       On macOS, `nuv-agent setup` / `nuv-agent run` will try to:
       1) install Homebrew (if missing),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.48"
+version = "0.1.49"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary\n- add a shared nuv-agent ASCII banner to Homebrew caveats and Debian postinst\n- bump release metadata to 0.1.49 so the new package assets align with the tag\n\n## Verification\n- ruby -c packaging/homebrew/nuv-agent.rb\n- bash -n packaging/deb/postinst\n- bash -n packaging/deb/build-deb.sh\n- python3 -m build --sdist in a temporary venv\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * nuv-agent 설치 시 스타일리시한 배너가 표시됩니다.

* **기타**
  * 버전을 0.1.48에서 0.1.49로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->