### PR TITLE
[codex] Show demo ground truth in overlay

### DIFF
--- a/nuvion_app/inference/demo_mvtec.py
+++ b/nuvion_app/inference/demo_mvtec.py
@@ -28,6 +28,8 @@ class MvtecDemoSource:
     extension: str
     slideshow_caps: str
     decoder: str
+    image_duration_sec: float
+    ground_truth_labels: tuple[str, ...]
 
 
 def parse_mvtec_categories(raw: str | None) -> tuple[str, ...]:
@@ -72,10 +74,9 @@ def prepare_mvtec_demo_source(
     rng = chooser or random.SystemRandom()
     category = rng.choice(resolved_categories)
     extracted_dir = ensure_mvtec_category_cached(resolved_base_url, resolved_cache_dir, category)
-    image_dir = resolve_mvtec_good_image_dir(extracted_dir, category)
-    image_paths = sorted(path for path in image_dir.iterdir() if path.is_file())
+    image_paths = collect_mvtec_demo_images(extracted_dir, category)
     if not image_paths:
-        raise ValueError(f"No images found for category '{category}' in {image_dir}")
+        raise ValueError(f"No demo images found for category '{category}' in {extracted_dir}")
 
     extension = image_paths[0].suffix.lower()
     if extension not in {".png", ".jpg", ".jpeg"}:
@@ -83,8 +84,10 @@ def prepare_mvtec_demo_source(
 
     stage_dir = build_stage_dir(resolved_cache_dir, category, image_paths, extension)
     stage_pattern = str(stage_dir / f"%05d{extension}")
-    slideshow_caps = build_slideshow_caps(extension, image_duration_sec or DEFAULT_DEMO_IMAGE_DURATION_SEC)
+    resolved_image_duration_sec = image_duration_sec or DEFAULT_DEMO_IMAGE_DURATION_SEC
+    slideshow_caps = build_slideshow_caps(extension, resolved_image_duration_sec)
     decoder = "pngdec" if extension == ".png" else "jpegdec"
+    ground_truth_labels = tuple(infer_mvtec_ground_truth_label(path) for path in image_paths)
     log.info("[DEMO] selected mvtec category=%s images=%s", category, len(image_paths))
     return MvtecDemoSource(
         category=category,
@@ -93,6 +96,8 @@ def prepare_mvtec_demo_source(
         extension=extension,
         slideshow_caps=slideshow_caps,
         decoder=decoder,
+        image_duration_sec=resolved_image_duration_sec,
+        ground_truth_labels=ground_truth_labels,
     )
 
 
@@ -140,20 +145,44 @@ def download_to_path(url: str, target_path: Path) -> None:
         raise
 
 
-def resolve_mvtec_good_image_dir(extracted_dir: Path, category: str) -> Path:
-    direct = extracted_dir / category / "train" / "good"
-    if direct.is_dir():
-        return direct
+def collect_mvtec_demo_images(extracted_dir: Path, category: str) -> list[Path]:
+    candidate_roots = [
+        extracted_dir / category / "test",
+        extracted_dir / "test",
+        extracted_dir / category / "train" / "good",
+        extracted_dir / "train" / "good",
+    ]
 
-    nested = extracted_dir / "train" / "good"
-    if nested.is_dir():
-        return nested
+    for root in candidate_roots:
+        if not root.exists():
+            continue
+        if root.name == "test":
+            image_paths = sorted(path for path in root.rglob("*") if path.is_file())
+        else:
+            image_paths = sorted(path for path in root.iterdir() if path.is_file())
+        if image_paths:
+            return image_paths
+
+    for path in extracted_dir.rglob("test"):
+        if not path.is_dir():
+            continue
+        image_paths = sorted(file_path for file_path in path.rglob("*") if file_path.is_file())
+        if image_paths:
+            return image_paths
 
     for path in extracted_dir.rglob("train/good"):
-        if path.is_dir():
-            return path
+        if not path.is_dir():
+            continue
+        image_paths = sorted(file_path for file_path in path.iterdir() if file_path.is_file())
+        if image_paths:
+            return image_paths
 
-    raise ValueError(f"Could not locate train/good images for category '{category}' in {extracted_dir}")
+    raise ValueError(f"Could not locate demo images for category '{category}' in {extracted_dir}")
+
+
+def infer_mvtec_ground_truth_label(image_path: Path) -> str:
+    normalized_parts = {part.lower() for part in image_path.parts}
+    return "normal" if "good" in normalized_parts else "defect"
 
 
 def build_stage_dir(cache_dir: Path, category: str, image_paths: list[Path], extension: str) -> Path:

--- a/nuvion_app/inference/pipeline.py
+++ b/nuvion_app/inference/pipeline.py
@@ -20,6 +20,7 @@ import shutil
 import subprocess
 import urllib.request
 import urllib.error
+from dataclasses import dataclass
 from urllib.parse import urlparse
 
 import numpy as np
@@ -28,6 +29,8 @@ import aiohttp
 import websockets
 from nuvion_app.inference.connectivity import ConnectivityReporter
 from nuvion_app.inference.connectivity import ConnectivityThresholds
+from nuvion_app.inference.demo_mvtec import MvtecDemoSource
+from nuvion_app.inference.demo_mvtec import prepare_mvtec_demo_source
 from nuvion_app.inference.webrtc_signaling import (
     WEBRTC_UPLINK_ANSWER,
     WEBRTC_UPLINK_ICE_CANDIDATE,
@@ -71,6 +74,34 @@ except Exception:
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s: %(message)s")
+
+OVERLAY_COLOR_WHITE = 0xFFFFFFFF
+OVERLAY_COLOR_GREEN = 0xFF00FF00
+OVERLAY_COLOR_RED = 0xFFFF0000
+DEMO_OVERLAY_STATUS_XPAD = 25
+DEMO_OVERLAY_LABEL_XPAD = 175
+DEMO_OVERLAY_SCORE_XPAD = 360
+DEMO_OVERLAY_GT_XPAD = 470
+
+
+@dataclass(frozen=True)
+class OverlayPayload:
+    status: str
+    label: str
+    score: float
+    ground_truth: str | None = None
+
+    @property
+    def score_text(self) -> str:
+        return f"{self.score:.2f}"
+
+    @property
+    def matches_ground_truth(self) -> bool | None:
+        if self.ground_truth == "normal":
+            return self.status == "NORMAL"
+        if self.ground_truth == "defect":
+            return self.status == "DEFECT"
+        return None
 
 
 def parse_csv(value: str) -> list[str]:
@@ -847,7 +878,7 @@ async def signaling_client_main():
 
 
 class NuvionEventState:
-    def __init__(self, overlay_callback=None):
+    def __init__(self, overlay_callback=None, demo_source: MvtecDemoSource | None = None):
         self.pipeline_started_at = time.time()
         self.running = True
         self.last_anomaly_at = 0.0
@@ -861,6 +892,11 @@ class NuvionEventState:
         self.clip_enabled = CLIP_ENABLED
         self.demo_mode = DEMO_MODE
         self.demo_tag = DEMO_TAG
+        self.demo_source = demo_source
+        self.demo_ground_truth_labels = tuple(demo_source.ground_truth_labels) if demo_source else ()
+        self.demo_image_duration_sec = float(demo_source.image_duration_sec) if demo_source else 0.0
+        self.demo_started_at = time.time()
+        self.current_demo_ground_truth = self.demo_ground_truth_labels[0] if self.demo_ground_truth_labels else None
         self.clip_in_progress = False
         self.clip_last_started = 0.0
         self.clip_lock = threading.Lock()
@@ -890,6 +926,28 @@ class NuvionEventState:
 
         self.worker_thread = threading.Thread(target=self._zsad_worker, daemon=True)
         self.worker_thread.start()
+
+    def reset_demo_timing(self) -> None:
+        self.demo_started_at = time.time()
+        if self.demo_ground_truth_labels:
+            self.current_demo_ground_truth = self.demo_ground_truth_labels[0]
+
+    def update_demo_ground_truth(self, pts_ns: int | None) -> None:
+        if not self.demo_mode or not self.demo_ground_truth_labels:
+            return
+
+        index: int | None = None
+        if pts_ns is not None and pts_ns != Gst.CLOCK_TIME_NONE and self.demo_image_duration_sec > 0:
+            duration_ns = max(1, int(self.demo_image_duration_sec * Gst.SECOND))
+            index = int(pts_ns // duration_ns)
+        elif self.demo_image_duration_sec > 0:
+            elapsed = max(0.0, time.time() - self.demo_started_at)
+            index = int(elapsed / self.demo_image_duration_sec)
+
+        if index is None:
+            return
+
+        self.current_demo_ground_truth = self.demo_ground_truth_labels[index % len(self.demo_ground_truth_labels)]
 
     def _get_or_create_triton_client(self):
         if TritonAnomalyClient is None:
@@ -1176,7 +1234,13 @@ class NuvionEventState:
                     label = result.get("label", "ZSAD")
                     score = float(result.get("score", 0.0))
                     status = "DEFECT" if is_anomaly else "NORMAL"
-                    self._emit_overlay(f"{status} {label} {score:.2f}")
+                    overlay = OverlayPayload(
+                        status=status,
+                        label=label,
+                        score=score,
+                        ground_truth=self.current_demo_ground_truth if self.demo_mode else None,
+                    )
+                    self._emit_overlay(overlay if self.demo_mode else f"{status} {label} {score:.2f}")
                     if status == "DEFECT":
                         self.send_status("DEFECT", label, f"Zero-shot anomaly: {label} ({score:.2f})", "WARNING")
                     else:
@@ -1203,7 +1267,13 @@ class NuvionEventState:
                 score = float(result.get("score", 0.0))
                 is_anomaly = score >= TRITON_THRESHOLD
                 status = "DEFECT" if is_anomaly else "NORMAL"
-                self._emit_overlay(f"{status} {label} {score:.2f}")
+                overlay = OverlayPayload(
+                    status=status,
+                    label=label,
+                    score=score,
+                    ground_truth=self.current_demo_ground_truth if self.demo_mode else None,
+                )
+                self._emit_overlay(overlay if self.demo_mode else f"{status} {label} {score:.2f}")
 
                 if status == "DEFECT":
                     self.send_status("DEFECT", label, f"Triton anomaly score={score:.2f}", "WARNING")
@@ -1241,6 +1311,7 @@ def on_new_sample(appsink, user_data: NuvionEventState):
         return Gst.FlowReturn.OK
 
     buffer.unmap(mapinfo)
+    user_data.update_demo_ground_truth(int(buffer.pts) if buffer.pts != Gst.CLOCK_TIME_NONE else None)
     user_data.maybe_enqueue_frame(frame)
     return Gst.FlowReturn.OK
 
@@ -1253,9 +1324,14 @@ class GStreamerInferenceApp:
         self.video_source = video_source
         self.demo_mode = DEMO_MODE
         self.demo_loop = DEMO_LOOP
+        self.demo_source = self._prepare_demo_source() if self.demo_mode else None
         self.rtp_ssrc = get_rtp_ssrc()
         self.overlay = None
-        self.user_data = NuvionEventState(self.update_overlay_text)
+        self.status_overlay = None
+        self.label_overlay = None
+        self.score_overlay = None
+        self.gt_overlay = None
+        self.user_data = NuvionEventState(self.update_overlay_text, demo_source=self.demo_source)
         self.webrtc_uplink = WebRTCUplinkController(
             send_message=self.send_webrtc_signal,
             default_force_relay=WEBRTC_FORCE_RELAY,
@@ -1271,6 +1347,14 @@ class GStreamerInferenceApp:
         global g_app
         g_app = self
 
+    def _prepare_demo_source(self) -> MvtecDemoSource | None:
+        return prepare_mvtec_demo_source(
+            base_url=os.getenv("NUVION_DEMO_MVTEC_BASE_URL"),
+            categories=os.getenv("NUVION_DEMO_MVTEC_CATEGORIES"),
+            cache_dir=os.getenv("NUVION_DEMO_MVTEC_CACHE_DIR"),
+            image_duration_sec=float(os.getenv("NUVION_DEMO_IMAGE_DURATION_SEC", "1.0")),
+        )
+
     def create_pipeline(self):
         Gst.init(None)
         source_pipeline = build_video_source_pipeline(
@@ -1280,17 +1364,62 @@ class GStreamerInferenceApp:
             self.frame_rate,
             gst_source_override=GST_SOURCE_OVERRIDE,
             demo_mode=self.demo_mode,
+            demo_source=self.demo_source,
         )
 
-        overlay_pipeline = (
-            "videoconvert ! "
-            "textoverlay name=zsad_overlay "
-            "font-desc=\"Sans 24\" "
-            "halignment=left valignment=top "
-            "shaded-background=true "
-            "text=\"\" "
-            "! "
-        )
+        if self.demo_mode:
+            overlay_pipeline = (
+                "videoconvert ! "
+                "textoverlay name=zsad_overlay "
+                "font-desc=\"Sans 24\" "
+                "halignment=left valignment=top "
+                "shaded-background=true "
+                "xpad=25 "
+                "text=\"\" "
+                "! "
+                "textoverlay name=zsad_status_overlay "
+                "font-desc=\"Monospace 24\" "
+                "halignment=left valignment=top "
+                f"xpad={DEMO_OVERLAY_STATUS_XPAD} "
+                "shaded-background=true "
+                "color=4294967295 "
+                "text=\"\" "
+                "! "
+                "textoverlay name=zsad_label_overlay "
+                "font-desc=\"Monospace 24\" "
+                "halignment=left valignment=top "
+                f"xpad={DEMO_OVERLAY_LABEL_XPAD} "
+                "shaded-background=true "
+                "color=4294967295 "
+                "text=\"\" "
+                "! "
+                "textoverlay name=zsad_score_overlay "
+                "font-desc=\"Monospace 24\" "
+                "halignment=left valignment=top "
+                f"xpad={DEMO_OVERLAY_SCORE_XPAD} "
+                "shaded-background=true "
+                "color=4294967295 "
+                "text=\"\" "
+                "! "
+                "textoverlay name=zsad_gt_overlay "
+                "font-desc=\"Monospace 24\" "
+                "halignment=left valignment=top "
+                f"xpad={DEMO_OVERLAY_GT_XPAD} "
+                "shaded-background=true "
+                "color=4294967295 "
+                "text=\"\" "
+                "! "
+            )
+        else:
+            overlay_pipeline = (
+                "videoconvert ! "
+                "textoverlay name=zsad_overlay "
+                "font-desc=\"Sans 24\" "
+                "halignment=left valignment=top "
+                "shaded-background=true "
+                "text=\"\" "
+                "! "
+            )
 
         encoder_pipeline = (
             "videoconvert ! "
@@ -1376,6 +1505,10 @@ class GStreamerInferenceApp:
             log.warning("[PIPELINE] zsad_overlay not found.")
         else:
             self.update_overlay_text(self._default_overlay_text())
+        self.status_overlay = self.pipeline.get_by_name("zsad_status_overlay")
+        self.label_overlay = self.pipeline.get_by_name("zsad_label_overlay")
+        self.score_overlay = self.pipeline.get_by_name("zsad_score_overlay")
+        self.gt_overlay = self.pipeline.get_by_name("zsad_gt_overlay")
 
         if self.webrtc_uplink and self.pipeline and not self.webrtc_uplink.attach_pipeline(self.pipeline):
             self.webrtc_uplink = None
@@ -1399,6 +1532,7 @@ class GStreamerInferenceApp:
             restart_result = self.pipeline.set_state(Gst.State.PLAYING)
             if restart_result == Gst.StateChangeReturn.FAILURE:
                 return False
+            self.user_data.reset_demo_timing()
             self.update_overlay_text(self._default_overlay_text())
             log.info("[DEMO] Restarted demo video (%s).", reason)
             return True
@@ -1431,13 +1565,43 @@ class GStreamerInferenceApp:
     def send_webrtc_signal(self, destination: str, payload: dict, remember: bool) -> bool:
         return enqueue_stomp_message(destination, payload, remember=remember)
 
-    def update_overlay_text(self, text: str):
+    def _set_overlay_field(self, overlay, text: str, color: int = OVERLAY_COLOR_WHITE) -> None:
+        if overlay is None:
+            return
+        overlay.set_property("text", text)
+        overlay.set_property("color", color)
+
+    def update_overlay_text(self, text: str | OverlayPayload):
         if not self.overlay:
             return
+
         def _apply():
-            if self.overlay:
-                self.overlay.set_property("text", text)
+            if not self.overlay:
+                return False
+
+            if self.demo_mode and isinstance(text, OverlayPayload):
+                match = text.matches_ground_truth
+                match_color = OVERLAY_COLOR_WHITE
+                if match is True:
+                    match_color = OVERLAY_COLOR_GREEN
+                elif match is False:
+                    match_color = OVERLAY_COLOR_RED
+
+                self.overlay.set_property("text", "")
+                self._set_overlay_field(self.status_overlay, text.status, match_color)
+                self._set_overlay_field(self.label_overlay, text.label)
+                self._set_overlay_field(self.score_overlay, text.score_text)
+                self._set_overlay_field(self.gt_overlay, text.ground_truth or "", match_color)
+                return False
+
+            resolved_text = text if isinstance(text, str) else f"{text.status} {text.label} {text.score_text}"
+            self.overlay.set_property("text", resolved_text)
+            self._set_overlay_field(self.status_overlay, "")
+            self._set_overlay_field(self.label_overlay, "")
+            self._set_overlay_field(self.score_overlay, "")
+            self._set_overlay_field(self.gt_overlay, "")
             return False
+
         GLib.idle_add(_apply)
 
     def _default_overlay_text(self) -> str:

--- a/nuvion_app/inference/video_source.py
+++ b/nuvion_app/inference/video_source.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 
+from nuvion_app.inference.demo_mvtec import MvtecDemoSource
 from nuvion_app.inference.demo_mvtec import prepare_mvtec_demo_source
 
 
@@ -21,6 +22,7 @@ def build_video_source_pipeline(
     gst_source_override: str | None = None,
     demo_mode: bool = False,
     platform_name: str | None = None,
+    demo_source: MvtecDemoSource | None = None,
 ) -> str:
     if gst_source_override and gst_source_override.strip():
         return gst_source_override.strip()
@@ -28,7 +30,7 @@ def build_video_source_pipeline(
     current_platform = platform_name or sys.platform
 
     if demo_mode:
-        mvtec_source = prepare_mvtec_demo_source(
+        mvtec_source = demo_source or prepare_mvtec_demo_source(
             base_url=os.getenv("NUVION_DEMO_MVTEC_BASE_URL"),
             categories=os.getenv("NUVION_DEMO_MVTEC_CATEGORIES"),
             cache_dir=os.getenv("NUVION_DEMO_MVTEC_CACHE_DIR"),

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.88}"
+VERSION="${VERSION:-0.1.89}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.88"
+  version "0.1.89"
   license "Proprietary"
 
   depends_on "python@3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.88"
+version = "0.1.89"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/inference/test_demo_mvtec.py
+++ b/tests/inference/test_demo_mvtec.py
@@ -7,6 +7,8 @@ from unittest import mock
 
 from nuvion_app.inference.demo_mvtec import build_slideshow_caps
 from nuvion_app.inference.demo_mvtec import build_stage_dir
+from nuvion_app.inference.demo_mvtec import collect_mvtec_demo_images
+from nuvion_app.inference.demo_mvtec import infer_mvtec_ground_truth_label
 from nuvion_app.inference.demo_mvtec import parse_mvtec_categories
 from nuvion_app.inference.demo_mvtec import validate_mvtec_demo_settings
 
@@ -42,6 +44,38 @@ class DemoMvtecTest(unittest.TestCase):
     def test_build_slideshow_caps_uses_fractional_rate(self) -> None:
         caps = build_slideshow_caps(".png", 2.0)
         self.assertEqual(caps, "image/png,framerate=1/2")
+
+    def test_collect_mvtec_demo_images_prefers_test_mix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "metal_nut" / "test"
+            (root / "good").mkdir(parents=True)
+            (root / "scratch").mkdir(parents=True)
+            (root / "good" / "000.png").write_bytes(b"good")
+            (root / "scratch" / "001.png").write_bytes(b"defect")
+
+            image_paths = collect_mvtec_demo_images(Path(tmp), "metal_nut")
+
+            self.assertEqual(
+                [path.relative_to(Path(tmp)).as_posix() for path in image_paths],
+                [
+                    "metal_nut/test/good/000.png",
+                    "metal_nut/test/scratch/001.png",
+                ],
+            )
+
+    def test_infer_mvtec_ground_truth_label_uses_good_as_normal(self) -> None:
+        self.assertEqual(
+            infer_mvtec_ground_truth_label(Path("/tmp/capsule/train/good/000.png")),
+            "normal",
+        )
+        self.assertEqual(
+            infer_mvtec_ground_truth_label(Path("/tmp/capsule/test/good/001.png")),
+            "normal",
+        )
+        self.assertEqual(
+            infer_mvtec_ground_truth_label(Path("/tmp/capsule/test/scratch/002.png")),
+            "defect",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/inference/test_video_source.py
+++ b/tests/inference/test_video_source.py
@@ -48,6 +48,25 @@ class VideoSourceTest(unittest.TestCase):
         self.assertIn(fake_source.stage_pattern, pipeline)
         self.assertIn(fake_source.decoder, pipeline)
 
+    def test_demo_mode_uses_provided_demo_source(self) -> None:
+        fake_source = mock.Mock(
+            stage_pattern="/tmp/mvtec/slides/cable/%05d.png",
+            slideshow_caps="image/png,framerate=1/2",
+            decoder="pngdec",
+        )
+        with mock.patch("nuvion_app.inference.video_source.prepare_mvtec_demo_source") as prepare_mock:
+            pipeline = build_video_source_pipeline(
+                "/dev/video0",
+                640,
+                480,
+                30,
+                demo_mode=True,
+                platform_name="linux",
+                demo_source=fake_source,
+            )
+        prepare_mock.assert_not_called()
+        self.assertIn(fake_source.stage_pattern, pipeline)
+
     def test_gst_override_takes_priority(self) -> None:
         pipeline = build_video_source_pipeline(
             "/dev/video0",


### PR DESCRIPTION
## What changed
- add demo-mode ground truth labels for MVTec slideshow frames
- show a 4th overlay field with demo GT (`normal` or `defect`)
- color the first status field and GT field green on match, red on mismatch
- bump package version from `0.1.88` to `0.1.89`

## Why
Demo playback now mixes good and defect samples, so the overlay needs to show the expected label for the current frame and make correctness visually obvious.

## Impact
- demo mode shows `status label score gt`
- `train/good` and `test/good` are treated as `normal`
- defect folders are treated as `defect`
- normal runtime behavior is unchanged outside demo mode

## Validation
- `python -m py_compile nuvion_app/inference/demo_mvtec.py nuvion_app/inference/video_source.py nuvion_app/inference/pipeline.py`
- `python -m unittest NUV-agent.tests.inference.test_demo_mvtec NUV-agent.tests.inference.test_video_source`
- local GStreamer pipeline construction verified with `videotestsrc`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 데모 모드에서 이미지 지속 시간 및 실제 레이블 추적 기능 강화
  * 오버레이 시스템을 구조화된 페이로드 기반으로 업그레이드하여 표시 정확성 개선
  * MVTec 데이터셋 이미지 수집 로직 최적화

* **테스트**
  * 이미지 수집 및 레이블 추론 기능에 대한 테스트 커버리지 추가

* **버전**
  * 0.1.89로 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->