### PR TITLE
Stop recentering when face tracking locks

### DIFF
--- a/nuvion_app/inference/pipeline.py
+++ b/nuvion_app/inference/pipeline.py
@@ -900,7 +900,6 @@ class NuvionEventState:
         self.zero_shot_queue = queue.Queue(maxsize=1)
         self.tracking_last_sample = 0.0
         self.tracking_queue = queue.Queue(maxsize=1)
-        self.tracking_centered = False
         self.overlay_callback = overlay_callback
         self.overlay_lock = threading.Lock()
         self.last_anomaly_overlay: str | OverlayPayload | None = None
@@ -1423,17 +1422,9 @@ class NuvionEventState:
             self.tracking_overlay_state.update(snapshot)
             self._set_tracking_status(decision.status_text)
 
-            if decision.primary_face is None:
-                self.tracking_centered = False
+            if decision.primary_face is None or decision.centered:
                 continue
 
-            if decision.centered:
-                if not self.tracking_centered:
-                    self.motor_controller.center()
-                self.tracking_centered = True
-                continue
-
-            self.tracking_centered = False
             if decision.pan_command is not None:
                 self.motor_controller.send_pan(decision.pan_command)
             if decision.tilt_command is not None:

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.91}"
+VERSION="${VERSION:-0.1.92}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.91"
+  version "0.1.92"
   license "Proprietary"
 
   depends_on "python@3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.91"
+version = "0.1.92"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- stop sending the motor center command when auto face tracking enters the deadzone
- keep the current motor position when a face is already centered
- bump version to 0.1.92

## Validation
- python -m py_compile nuvion_app/inference/pipeline.py
- python -m unittest tests.inference.test_motor tests.inference.test_face_tracking tests.inference.test_video_source tests.test_config_video_sources tests.test_config_qr_setup tests.runtime.test_config_guard tests.runtime.test_gstreamer_env