### PR TITLE
Require server presigned model downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,6 @@ nuv-agent pull-model \
 - 결과 메타데이터: `metadata/downloaded_from_server.json`
 
 ## Pull model bundle (GCS fallback)
-개발/운영 점검용 fallback으로 GCS 직접 pull도 유지됩니다.
-```bash
-nuv-agent pull-model \
-  --source gcs \
-  --gcs-pointer-uri gs://nuv-model/pointers/anomalyclip/prod.json \
-  --local-dir ~/.cache/nuvion/models/anomalyclip-current \
-  --profile runtime
-```
-
 Profiles:
 - `runtime`: Triton + text features 실행에 필요한 파일만 다운로드
 - `light`: text features/metadata 중심의 경량 다운로드
@@ -86,11 +77,9 @@ Profiles:
 - `artifacts.<key>.path`를 사용하는 v2 포맷을 모두 지원합니다.
 
 기본값:
-- `NUVION_MODEL_SOURCE=server`
 - `NUVION_MODEL_POINTER=anomalyclip/prod`
 - `NUVION_MODEL_PRESIGN_TTL_SECONDS=300`
 - `NUVION_MODEL_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io`
-- `NUVION_MODEL_GCS_POINTER_URI=gs://nuv-model/pointers/anomalyclip/prod.json`
 - `NUVION_MODEL_PROFILE=runtime`
 - `NUVION_MODEL_LOCAL_DIR=~/.cache/nuvion/models/anomalyclip-current`
 
@@ -255,12 +244,10 @@ For dev, `.env` in the repo is used automatically.
 - `NUVION_ZSAD_BACKEND`: `triton|siglip|mps|none` (`mps`는 `siglip + NUVION_ZERO_SHOT_DEVICE=mps` alias)
 - `NUVION_ZERO_SHOT_MODEL`: 기본 ZSAD 모델 (`google/siglip2-base-patch16-224`)
 - `NUVION_ZERO_SHOT_DEVICE`: SigLIP 디바이스 우선순위 (`auto|mps|cuda|cpu`, 기본 `auto`)
-- `NUVION_MODEL_SOURCE`: `server`(권장) | `gcs`(fallback)
-- `NUVION_MODEL_POINTER`: server source에서 사용할 pointer (`anomalyclip/prod`)
-- `NUVION_MODEL_PRESIGN_TTL_SECONDS`: server source presign 요청 TTL
-- `NUVION_MODEL_SERVER_BASE_URL`: server source presign API base URL
-- `NUVION_MODEL_SERVER_ACCESS_TOKEN`: server source에서 사용할 사전 발급 토큰(선택)
-- `NUVION_MODEL_GCS_POINTER_URI`: GCS pointer JSON URI (default: `gs://nuv-model/pointers/anomalyclip/prod.json`)
+- `NUVION_MODEL_POINTER`: 서버가 해석할 model pointer (`anomalyclip/prod`)
+- `NUVION_MODEL_PRESIGN_TTL_SECONDS`: server presign 요청 TTL
+- `NUVION_MODEL_SERVER_BASE_URL`: server presign API base URL
+- `NUVION_MODEL_SERVER_ACCESS_TOKEN`: 사전 발급 토큰(선택). 미지정 시 setup에서 저장된 device credential로 로그인 후 다운로드
 - `NUVION_MODEL_PROFILE`: pull-model 프로필 (`runtime|light|full`)
 - `NUVION_MODEL_DIR`: pull-model 기본 저장 루트
 - `NUVION_CONFIG_SCHEMA_VERSION`: config schema 버전 (`doctor --fix`로 자동 보정)

--- a/nuvion_app/cli.py
+++ b/nuvion_app/cli.py
@@ -16,13 +16,10 @@ from nuvion_app.config import (
 from nuvion_app.model_store import (
     DEFAULT_MODEL_POINTER,
     DEFAULT_MODEL_PRESIGN_TTL_SECONDS,
-    DEFAULT_MODEL_GCS_POINTER_URI,
     DEFAULT_MODEL_SERVER_BASE_URL,
-    DEFAULT_MODEL_SOURCE,
     DEFAULT_MODEL_PROFILE,
     anomalyclip_text_features_path,
     anomalyclip_triton_repository_path,
-    pull_model_from_gcs,
     pull_model_from_server,
     resolve_default_model_dir,
 )
@@ -78,24 +75,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
     pull_parser = subparsers.add_parser(
         "pull-model",
-        help="Download model artifacts for Triton/AnomalyCLIP runtime (source=gcs|server)",
+        help="Download model artifacts for Triton/AnomalyCLIP runtime via server presigned URLs",
     )
     pull_parser.add_argument("--config", help="Path to config env file")
     pull_parser.add_argument(
-        "--source",
-        choices=("gcs", "server"),
-        default=os.getenv("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE),
-        help="Model artifact source",
-    )
-    pull_parser.add_argument(
-        "--gcs-pointer-uri",
-        default=os.getenv("NUVION_MODEL_GCS_POINTER_URI", DEFAULT_MODEL_GCS_POINTER_URI),
-        help="GCS pointer JSON URI (used when --source gcs)",
-    )
-    pull_parser.add_argument(
         "--pointer",
         default=os.getenv("NUVION_MODEL_POINTER", DEFAULT_MODEL_POINTER),
-        help="Pointer identifier (used when --source server), e.g. anomalyclip/prod",
+        help="Pointer identifier resolved by the server, e.g. anomalyclip/prod",
     )
     pull_parser.add_argument(
         "--server-base-url",
@@ -227,33 +213,23 @@ def main() -> None:
     if args.command == "pull-model":
         load_env(args.config)
         try:
-            source = (args.source or DEFAULT_MODEL_SOURCE).strip().lower()
-            if source == "server":
-                pointer = (args.pointer or DEFAULT_MODEL_POINTER).strip()
-                local_dir = args.local_dir.strip() or str(resolve_default_model_dir(f"server:{pointer}:{args.profile}"))
-                server_base_url = (args.server_base_url or os.getenv("NUVION_SERVER_BASE_URL", "")).strip()
-                access_token = (args.access_token or "").strip() or None
-                username = (args.username or "").strip() or None
-                password = (args.password or "").strip() or None
+            pointer = (args.pointer or DEFAULT_MODEL_POINTER).strip()
+            local_dir = args.local_dir.strip() or str(resolve_default_model_dir(f"server:{pointer}:{args.profile}"))
+            server_base_url = (args.server_base_url or os.getenv("NUVION_SERVER_BASE_URL", "")).strip()
+            access_token = (args.access_token or "").strip() or None
+            username = (args.username or "").strip() or None
+            password = (args.password or "").strip() or None
 
-                model_dir, _ = pull_model_from_server(
-                    server_base_url=server_base_url,
-                    pointer=pointer,
-                    profile=args.profile,
-                    local_dir=local_dir,
-                    ttl_seconds=args.ttl_seconds,
-                    access_token=access_token,
-                    username=username,
-                    password=password,
-                )
-            else:
-                pointer_uri = args.gcs_pointer_uri.strip() or DEFAULT_MODEL_GCS_POINTER_URI
-                local_dir = args.local_dir.strip() or str(resolve_default_model_dir(pointer_uri))
-                model_dir, _ = pull_model_from_gcs(
-                    pointer_uri=pointer_uri,
-                    local_dir=local_dir,
-                    profile=args.profile,
-                )
+            model_dir, _ = pull_model_from_server(
+                server_base_url=server_base_url,
+                pointer=pointer,
+                profile=args.profile,
+                local_dir=local_dir,
+                ttl_seconds=args.ttl_seconds,
+                access_token=access_token,
+                username=username,
+                password=password,
+            )
         except Exception as exc:
             sys.stderr.write(f"Failed to pull model artifacts: {exc}\n")
             sys.exit(1)
@@ -262,7 +238,7 @@ def main() -> None:
         triton_repo = anomalyclip_triton_repository_path(model_dir)
 
         sys.stdout.write(f"Model artifacts downloaded to: {model_dir}\n")
-        sys.stdout.write(f"Source: {args.source}\n")
+        sys.stdout.write("Source: server\n")
         if text_features.exists():
             sys.stdout.write("Suggested env for AnomalyCLIP Triton backend:\n")
             sys.stdout.write("  NUVION_ZSAD_BACKEND=triton\n")

--- a/nuvion_app/config_template.env
+++ b/nuvion_app/config_template.env
@@ -115,15 +115,13 @@ NUVION_TRITON_MAC_PROFILE=full
 NUVION_TRITON_RPI_PROFILE=full
 NUVION_TRITON_JETSON_PROFILE=runtime
 
-# Model bundle (for `nuv-agent pull-model`)
-# source: server (recommended) | gcs (fallback)
-NUVION_MODEL_SOURCE=server
+# Model bundle (for `nuv-agent pull-model` and runtime bootstrap)
+# Models are downloaded via server-issued presigned URLs only.
 NUVION_MODEL_POINTER=anomalyclip/prod
 NUVION_MODEL_PRESIGN_TTL_SECONDS=300
 NUVION_MODEL_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io
-# Optional: pre-issued bearer token for server source
+# Optional: pre-issued bearer token. If omitted, setup-saved device credentials are used.
 # NUVION_MODEL_SERVER_ACCESS_TOKEN=
-NUVION_MODEL_GCS_POINTER_URI=gs://nuv-model/pointers/anomalyclip/prod.json
 NUVION_MODEL_PROFILE=runtime
 NUVION_MODEL_DIR=~/.cache/nuvion/models
 NUVION_MODEL_LOCAL_DIR=~/.cache/nuvion/models/anomalyclip-current

--- a/nuvion_app/model_store.py
+++ b/nuvion_app/model_store.py
@@ -17,7 +17,6 @@ DEFAULT_MODEL_PROFILE = "runtime"
 DEFAULT_MODEL_POINTER = "anomalyclip/prod"
 DEFAULT_MODEL_PRESIGN_TTL_SECONDS = 300
 DEFAULT_MODEL_SERVER_BASE_URL = "https://api.nuvion-dev.plaidai.io"
-DEFAULT_MODEL_GCS_POINTER_URI = "gs://nuv-model/pointers/anomalyclip/prod.json"
 DEFAULT_MODEL_PRESIGN_REFRESH_RETRIES = 2
 DEFAULT_FACE_TRACKING_MODEL_URL = (
     "https://github.com/onnx/models/raw/main/validated/vision/body_analysis/ultraface/models/version-RFB-640.onnx"
@@ -110,34 +109,6 @@ def _run_command(cmd: list[str], capture_output: bool = False) -> subprocess.Com
     except subprocess.CalledProcessError as exc:
         detail = exc.stderr.strip() if exc.stderr else str(exc)
         raise RuntimeError(detail) from exc
-
-
-def _parse_gs_uri(uri: str) -> tuple[str, str]:
-    if not uri.startswith("gs://"):
-        raise ValueError(f"Expected gs:// URI, got: {uri}")
-    trimmed = uri[5:]
-    bucket, _, object_path = trimmed.partition("/")
-    if not bucket:
-        raise ValueError(f"Invalid gs:// URI (missing bucket): {uri}")
-    return bucket, object_path
-
-
-def _gcs_uri(bucket: str, object_path: str) -> str:
-    object_path = object_path.lstrip("/")
-    return f"gs://{bucket}/{object_path}"
-
-
-def _gcs_cat_json(uri: str) -> dict[str, Any]:
-    result = _run_command(["gcloud", "storage", "cat", uri], capture_output=True)
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"Invalid JSON in pointer: {uri}") from exc
-
-
-def _copy_gcs_object(src_uri: str, dst_path: Path) -> None:
-    dst_path.parent.mkdir(parents=True, exist_ok=True)
-    _run_command(["gcloud", "storage", "cp", src_uri, str(dst_path)])
 
 
 def _sha256_file(path: Path) -> str:
@@ -457,63 +428,6 @@ def _download_http_file(
                 time.sleep(min(0.5 * (2 ** (attempt - 1)), 4.0))
 
     raise RuntimeError(f"Download failed after {max_retries} attempts: {url} ({last_error})")
-
-
-def pull_model_from_gcs(
-    pointer_uri: str,
-    local_dir: Optional[str] = None,
-    profile: str = DEFAULT_MODEL_PROFILE,
-    extra_keys: Optional[list[str]] = None,
-    optional_keys: Optional[list[str]] = None,
-) -> tuple[Path, dict[str, Any]]:
-    _ensure_profile(profile)
-
-    bucket, _ = _parse_gs_uri(pointer_uri)
-    pointer = _gcs_cat_json(pointer_uri)
-
-    artifacts = pointer.get("artifacts")
-    if not isinstance(artifacts, dict):
-        raise RuntimeError("Pointer JSON must include 'artifacts' object")
-
-    runtime_layout = pointer.get("runtime_layout")
-    local_paths: dict[str, str] = {}
-    if isinstance(runtime_layout, dict):
-        lp = runtime_layout.get("local_paths")
-        if isinstance(lp, dict):
-            local_paths = {str(k): str(v) for k, v in lp.items()}
-
-    target_dir = _resolve_local_dir(identifier=pointer_uri, local_dir=local_dir)
-    target_dir.mkdir(parents=True, exist_ok=True)
-
-    required_keys = merge_required_keys(_resolve_profile_keys(pointer, profile), extra_keys)
-    fetch_keys = merge_required_keys(required_keys, [key for key in (optional_keys or []) if key in artifacts])
-    missing = [key for key in required_keys if key not in artifacts]
-    if missing:
-        raise RuntimeError(f"Pointer is missing required artifacts for profile '{profile}': {', '.join(missing)}")
-
-    downloaded: list[dict[str, Any]] = []
-    for key in fetch_keys:
-        src_obj, expected_sha256, expected_size = _artifact_path_from_pointer(artifacts[key], key)
-        # Support both relative object paths and absolute gs:// URIs from pointer artifacts.
-        src_uri = src_obj if src_obj.startswith("gs://") else _gcs_uri(bucket, src_obj)
-        local_rel = local_paths.get(key, _resolve_local_rel_path(key, src_obj))
-        dst = (target_dir / local_rel).resolve()
-        _copy_gcs_object(src_uri=src_uri, dst_path=dst)
-        _validate_download_integrity(dst, expected_sha256, expected_size, key)
-        downloaded.append({
-            "key": key,
-            "src": src_uri,
-            "dst": str(dst),
-            "sha256": expected_sha256,
-            "sizeBytes": expected_size,
-        })
-
-    metadata_dir = (target_dir / "metadata").resolve()
-    metadata_dir.mkdir(parents=True, exist_ok=True)
-    _write_json(metadata_dir / "gcs_pointer.json", pointer)
-    _write_json(metadata_dir / "downloaded_from_gcs.json", downloaded)
-
-    return target_dir, pointer
 
 
 def pull_model_from_server(

--- a/nuvion_app/runtime/config_guard.py
+++ b/nuvion_app/runtime/config_guard.py
@@ -8,10 +8,15 @@ from typing import Dict, List, Tuple
 from nuvion_app.config import effective_required_keys, load_template, read_env, write_env
 from nuvion_app.inference.demo_mvtec import validate_mvtec_demo_settings
 from nuvion_app.model_store import DEFAULT_MODEL_PROFILE, DEFAULT_MODEL_SOURCE
-from nuvion_app.runtime.inference_mode import normalize_backend, normalize_face_tracking_backend, normalize_siglip_device
+from nuvion_app.runtime.inference_mode import (
+    face_tracking_uses_triton,
+    normalize_backend,
+    normalize_face_tracking_backend,
+    normalize_siglip_device,
+)
 
 CURRENT_CONFIG_SCHEMA_VERSION = "5"
-_VALID_MODEL_SOURCES = {"server", "gcs"}
+_VALID_MODEL_SOURCES = {"server"}
 _VALID_MODEL_PROFILES = {"runtime", "light", "full"}
 _VALID_TRITON_INPUT_FORMATS = {"NCHW", "NHWC"}
 _VALID_VIDEO_ROTATIONS = {"0", "90", "180", "270"}
@@ -117,7 +122,7 @@ def _apply_migrations(values: Dict[str, str]) -> List[str]:
 
     source = (values.get("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE) or DEFAULT_MODEL_SOURCE).strip().lower()
     if source not in _VALID_MODEL_SOURCES:
-        update("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE, "invalid model source fallback")
+        update("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE, "force server-only model source")
 
     profile = (values.get("NUVION_MODEL_PROFILE", DEFAULT_MODEL_PROFILE) or DEFAULT_MODEL_PROFILE).strip().lower()
     if profile not in _VALID_MODEL_PROFILES:
@@ -223,10 +228,10 @@ def _validate_values(values: Dict[str, str]) -> tuple[List[ConfigIssue], List[Co
             errors.append(ConfigIssue(key=key, message="필수 값이 비어있거나 placeholder입니다."))
 
     backend = normalize_backend(values.get("NUVION_ZSAD_BACKEND", "triton"), default="triton")
-    source = (values.get("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE) or DEFAULT_MODEL_SOURCE).strip().lower()
+    source = "server"
 
     if source not in _VALID_MODEL_SOURCES:
-        errors.append(ConfigIssue(key="NUVION_MODEL_SOURCE", message="지원하지 않는 모델 source입니다. (server|gcs)"))
+        errors.append(ConfigIssue(key="NUVION_MODEL_SOURCE", message="모델 다운로드는 server source만 지원합니다."))
 
     if _is_truthy(values.get("NUVION_DEMO_MODE", "false")):
         try:
@@ -278,7 +283,12 @@ def _validate_values(values: Dict[str, str]) -> tuple[List[ConfigIssue], List[Co
     except Exception:
         errors.append(ConfigIssue(key="NUVION_FACE_TRACKING_THRESHOLD", message="0보다 크고 1 이하이어야 합니다."))
 
-    if backend == "triton":
+    requires_server_model_auth = backend == "triton" or face_tracking_uses_triton(
+        enabled=_is_truthy(values.get("NUVION_FACE_TRACKING_ENABLED", "false")),
+        backend=values.get("NUVION_FACE_TRACKING_BACKEND", "auto"),
+    )
+
+    if requires_server_model_auth:
         triton_url = (values.get("NUVION_TRITON_URL", "") or "").strip()
         if not triton_url:
             errors.append(ConfigIssue(key="NUVION_TRITON_URL", message="Triton backend 사용 시 NUVION_TRITON_URL이 필요합니다."))
@@ -299,18 +309,23 @@ def _validate_values(values: Dict[str, str]) -> tuple[List[ConfigIssue], List[Co
             except Exception:
                 errors.append(ConfigIssue(key=key, message="양수 정수여야 합니다."))
 
-        if source == "server":
-            pointer = (values.get("NUVION_MODEL_POINTER", "") or "").strip()
-            if not pointer:
-                errors.append(ConfigIssue(key="NUVION_MODEL_POINTER", message="server source 사용 시 pointer가 필요합니다."))
-            server_url = (values.get("NUVION_MODEL_SERVER_BASE_URL", "") or "").strip()
-            if not server_url:
-                errors.append(ConfigIssue(key="NUVION_MODEL_SERVER_BASE_URL", message="server source 사용 시 base URL이 필요합니다."))
+        pointer = (values.get("NUVION_MODEL_POINTER", "") or "").strip()
+        if not pointer:
+            errors.append(ConfigIssue(key="NUVION_MODEL_POINTER", message="모델 presign 요청에는 pointer가 필요합니다."))
+        server_url = (values.get("NUVION_MODEL_SERVER_BASE_URL", "") or "").strip()
+        if not server_url:
+            errors.append(ConfigIssue(key="NUVION_MODEL_SERVER_BASE_URL", message="모델 presign 요청에는 server base URL이 필요합니다."))
 
-        if source == "gcs":
-            pointer_uri = (values.get("NUVION_MODEL_GCS_POINTER_URI", "") or "").strip()
-            if not pointer_uri.startswith("gs://"):
-                errors.append(ConfigIssue(key="NUVION_MODEL_GCS_POINTER_URI", message="gcs source 사용 시 gs:// URI가 필요합니다."))
+        access_token = (values.get("NUVION_MODEL_SERVER_ACCESS_TOKEN", "") or "").strip()
+        username = (values.get("NUVION_DEVICE_USERNAME", "") or "").strip()
+        password = values.get("NUVION_DEVICE_PASSWORD", "") or ""
+        if not access_token and (not username or _is_placeholder(password)):
+            errors.append(
+                ConfigIssue(
+                    key="NUVION_DEVICE_PASSWORD",
+                    message="모델 다운로드는 setup에서 저장된 device credential 또는 NUVION_MODEL_SERVER_ACCESS_TOKEN이 필요합니다.",
+                )
+            )
 
         mode = (values.get("NUVION_TRITON_MODE", "generic") or "generic").strip().lower()
         if mode == "anomalyclip":

--- a/nuvion_app/runtime/model_guard.py
+++ b/nuvion_app/runtime/model_guard.py
@@ -6,17 +6,14 @@ import sys
 from pathlib import Path
 
 from nuvion_app.model_store import (
-    DEFAULT_MODEL_GCS_POINTER_URI,
     DEFAULT_MODEL_POINTER,
     DEFAULT_MODEL_PRESIGN_TTL_SECONDS,
     DEFAULT_MODEL_PROFILE,
     DEFAULT_MODEL_SERVER_BASE_URL,
-    DEFAULT_MODEL_SOURCE,
     _DEFAULT_LOCAL_PATHS,
     _PROFILE_KEYS,
     ensure_default_face_tracking_model,
     merge_required_keys,
-    pull_model_from_gcs,
     pull_model_from_server,
     resolve_default_model_dir,
 )
@@ -95,14 +92,9 @@ def resolve_model_dir(profile: str) -> Path:
     if explicit:
         return Path(explicit).expanduser().resolve()
 
-    source = (os.getenv("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE) or DEFAULT_MODEL_SOURCE).strip().lower()
-    if source == "server":
-        pointer = (os.getenv("NUVION_MODEL_POINTER", DEFAULT_MODEL_POINTER) or DEFAULT_MODEL_POINTER).strip()
-        identifier = f"server:{pointer}:{profile}"
-        return resolve_default_model_dir(identifier)
-
-    gcs_pointer_uri = (os.getenv("NUVION_MODEL_GCS_POINTER_URI", DEFAULT_MODEL_GCS_POINTER_URI) or DEFAULT_MODEL_GCS_POINTER_URI).strip()
-    return resolve_default_model_dir(gcs_pointer_uri)
+    pointer = (os.getenv("NUVION_MODEL_POINTER", DEFAULT_MODEL_POINTER) or DEFAULT_MODEL_POINTER).strip()
+    identifier = f"server:{pointer}:{profile}"
+    return resolve_default_model_dir(identifier)
 
 
 def _required_model_keys(profile: str) -> list[str]:
@@ -145,26 +137,17 @@ def _pull_model(profile: str, model_dir: Path) -> None:
         ensure_default_face_tracking_model(model_dir)
         return
 
-    source = (os.getenv("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE) or DEFAULT_MODEL_SOURCE).strip().lower()
-    if source == "server":
-        pull_model_from_server(
-            server_base_url=(os.getenv("NUVION_MODEL_SERVER_BASE_URL", os.getenv("NUVION_SERVER_BASE_URL", DEFAULT_MODEL_SERVER_BASE_URL)) or DEFAULT_MODEL_SERVER_BASE_URL).strip(),
-            pointer=(os.getenv("NUVION_MODEL_POINTER", DEFAULT_MODEL_POINTER) or DEFAULT_MODEL_POINTER).strip(),
-            profile=profile,
-            local_dir=str(model_dir),
-            ttl_seconds=int(os.getenv("NUVION_MODEL_PRESIGN_TTL_SECONDS", str(DEFAULT_MODEL_PRESIGN_TTL_SECONDS))),
-            access_token=(os.getenv("NUVION_MODEL_SERVER_ACCESS_TOKEN") or "").strip() or None,
-            username=(os.getenv("NUVION_DEVICE_USERNAME") or "").strip() or None,
-            password=(os.getenv("NUVION_DEVICE_PASSWORD") or "").strip() or None,
-            optional_keys=optional_tracking_keys,
-        )
-    else:
-        pull_model_from_gcs(
-            pointer_uri=(os.getenv("NUVION_MODEL_GCS_POINTER_URI", DEFAULT_MODEL_GCS_POINTER_URI) or DEFAULT_MODEL_GCS_POINTER_URI).strip(),
-            local_dir=str(model_dir),
-            profile=profile,
-            optional_keys=optional_tracking_keys,
-        )
+    pull_model_from_server(
+        server_base_url=(os.getenv("NUVION_MODEL_SERVER_BASE_URL", os.getenv("NUVION_SERVER_BASE_URL", DEFAULT_MODEL_SERVER_BASE_URL)) or DEFAULT_MODEL_SERVER_BASE_URL).strip(),
+        pointer=(os.getenv("NUVION_MODEL_POINTER", DEFAULT_MODEL_POINTER) or DEFAULT_MODEL_POINTER).strip(),
+        profile=profile,
+        local_dir=str(model_dir),
+        ttl_seconds=int(os.getenv("NUVION_MODEL_PRESIGN_TTL_SECONDS", str(DEFAULT_MODEL_PRESIGN_TTL_SECONDS))),
+        access_token=(os.getenv("NUVION_MODEL_SERVER_ACCESS_TOKEN") or "").strip() or None,
+        username=(os.getenv("NUVION_DEVICE_USERNAME") or "").strip() or None,
+        password=(os.getenv("NUVION_DEVICE_PASSWORD") or "").strip() or None,
+        optional_keys=optional_tracking_keys,
+    )
 
     if tracking_uses_triton:
         _ensure_optional_face_tracking_assets(model_dir)
@@ -189,15 +172,13 @@ def ensure_model_ready(stage: str) -> Path:
 
     try:
         log.info(
-            "[BOOTSTRAP] Missing model artifacts detected (%s). Pulling profile=%s source=%s",
+            "[BOOTSTRAP] Missing model artifacts detected (%s). Pulling profile=%s via server presign",
             ", ".join(missing_before),
             os.getenv("NUVION_MODEL_PROFILE", DEFAULT_MODEL_PROFILE),
-            os.getenv("NUVION_MODEL_SOURCE", DEFAULT_MODEL_SOURCE),
         )
         _emit_progress(
             f"모델 파일 누락 감지({len(missing_before)}개). "
-            f"자동 다운로드 시작: source={os.getenv('NUVION_MODEL_SOURCE', DEFAULT_MODEL_SOURCE)} "
-            f"profile={profile}"
+            f"자동 다운로드 시작: source=server profile={profile}"
         )
         _pull_model(profile=profile, model_dir=model_dir)
         _emit_progress("모델 다운로드 완료. 무결성 점검 중...")

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.93}"
+VERSION="${VERSION:-0.1.94}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.93"
+  version "0.1.94"
   license "Proprietary"
 
   depends_on "python@3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.93"
+version = "0.1.94"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/runtime/test_config_guard.py
+++ b/tests/runtime/test_config_guard.py
@@ -184,6 +184,26 @@ class ConfigGuardTest(unittest.TestCase):
             self.assertTrue(report.ok)
             self.assertEqual(report.values["NUVION_FACE_TRACKING_BACKEND"], "auto")
 
+    def test_guard_requires_device_credentials_or_access_token_for_model_download(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "agent.env"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "NUVION_SERVER_BASE_URL=https://api.example.com",
+                        "NUVION_DEVICE_USERNAME=device-1",
+                        "NUVION_DEVICE_PASSWORD=***",
+                        "NUVION_ZSAD_BACKEND=triton",
+                        "",
+                    ]
+                )
+            )
+
+            report = guard_config(config_path=config_path, apply_fixes=True)
+
+            self.assertFalse(report.ok)
+            self.assertTrue(any("device credential" in issue.message for issue in report.errors))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runtime/test_model_guard.py
+++ b/tests/runtime/test_model_guard.py
@@ -72,11 +72,9 @@ class ModelGuardTest(unittest.TestCase):
             ):
                 with mock.patch.object(model_guard, "ensure_default_face_tracking_model") as ensure_face_model:
                     with mock.patch.object(model_guard, "pull_model_from_server") as pull_server:
-                        with mock.patch.object(model_guard, "pull_model_from_gcs") as pull_gcs:
-                            model_guard._pull_model("runtime", Path(tmp))
+                        model_guard._pull_model("runtime", Path(tmp))
         ensure_face_model.assert_called_once()
         pull_server.assert_not_called()
-        pull_gcs.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_model_store_selfheal.py
+++ b/tests/runtime/test_model_store_selfheal.py
@@ -91,51 +91,5 @@ class ModelStoreSelfHealTest(unittest.TestCase):
             self.assertTrue((Path(target_dir) / "onnx" / "text_features.npy").exists())
             self.assertTrue((Path(target_dir) / "metadata" / "gcs_manifest.json").exists())
 
-    def test_pull_model_from_gcs_supports_absolute_gs_uri(self) -> None:
-        pointer = {
-            "artifacts": {
-                "text_features": {
-                    "path": "gs://alt-bucket/path/text_features.npy",
-                    "sha256": "a" * 64,
-                    "sizeBytes": 8,
-                },
-                "manifest": {
-                    "path": "nuvion/anomalyclip/v0001/source/gcs_manifest.json",
-                    "sha256": "b" * 64,
-                    "sizeBytes": 8,
-                },
-            },
-            "profiles": {
-                "light": ["text_features", "manifest"],
-            },
-        }
-        copied: list[str] = []
-
-        def fake_copy(src_uri: str, dst_path: Path) -> None:
-            copied.append(src_uri)
-            dst_path.parent.mkdir(parents=True, exist_ok=True)
-            dst_path.write_bytes(b"12345678")
-
-        with tempfile.TemporaryDirectory() as tmp:
-            with mock.patch.object(model_store, "_gcs_cat_json", return_value=pointer):
-                with mock.patch.object(model_store, "_copy_gcs_object", side_effect=fake_copy):
-                    with mock.patch.object(model_store, "_validate_download_integrity", return_value=None):
-                        target_dir, _ = model_store.pull_model_from_gcs(
-                            pointer_uri="gs://nuv-model/pointers/anomalyclip/prod.json",
-                            local_dir=tmp,
-                            profile="light",
-                        )
-                        self.assertTrue((Path(target_dir) / "onnx" / "text_features.npy").exists())
-                        self.assertTrue((Path(target_dir) / "metadata" / "gcs_manifest.json").exists())
-
-        self.assertEqual(
-            copied,
-            [
-                "gs://alt-bucket/path/text_features.npy",
-                "gs://nuv-model/nuvion/anomalyclip/v0001/source/gcs_manifest.json",
-            ],
-        )
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- remove direct GCS model download support from runtime and CLI
- require server presigned URLs for all model downloads
- make setup-saved device credentials or a model access token required for model bootstrap
- bump version to 0.1.94

## Validation
- python -m unittest tests.runtime.test_model_store_selfheal tests.runtime.test_model_guard tests.runtime.test_config_guard tests.runtime.test_bootstrap tests.runtime.test_inference_mode tests.agent.test_triton_face_client tests.inference.test_face_tracking tests.inference.test_motor tests.inference.test_video_source tests.test_config_video_sources tests.test_config_qr_setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 모델 다운로드 방식 단순화를 반영하여 README 및 설정 가이드 업데이트

* **리팩토링**
  * 모델 다운로드를 서버 기반 방식으로 통합 (GCS 직접 접근 제거)
  * pull-model 커맨드 라인 옵션 간소화

* **기타**
  * 버전 0.1.94로 업데이트
  * 테스트 코드 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->