### PR TITLE
[codex] Harden Jetson Triton face tracking bootstrap

### DIFF
--- a/nuvion_app/agent/triton_face_client.py
+++ b/nuvion_app/agent/triton_face_client.py
@@ -98,8 +98,19 @@ class TritonFaceClient:
         self.nms_iou = float(os.getenv("NUVION_FACE_TRACKING_NMS_IOU", "0.3") or "0.3")
 
         self.client = httpclient.InferenceServerClient(url=self.url)
+        self._ensure_model_ready()
         self._sync_output_names_from_metadata()
         self._sync_input_shape_from_config()
+
+    def _ensure_model_ready(self) -> None:
+        try:
+            if hasattr(self.client, "is_model_ready"):
+                ready = self.client.is_model_ready(model_name=self.model_name)
+                if ready is False:
+                    raise RuntimeError("model is not ready")
+            self.client.get_model_metadata(model_name=self.model_name)
+        except Exception as exc:
+            raise RuntimeError(f"Triton model '{self.model_name}' is not ready: {exc}") from exc
 
     def _sync_input_shape_from_config(self) -> None:
         try:

--- a/nuvion_app/config_template.env
+++ b/nuvion_app/config_template.env
@@ -25,6 +25,7 @@ NUVION_VIDEO_FLIP_HORIZONTAL=false
 NUVION_VIDEO_FLIP_VERTICAL=false
 # Face tracking + motor control
 NUVION_FACE_TRACKING_ENABLED=false
+# auto prefers Triton. Jetson uses a TensorRT plan when available and falls back to ONNX only if needed.
 NUVION_FACE_TRACKING_BACKEND=auto
 NUVION_FACE_TRACKING_MODEL=face_detector
 NUVION_FACE_TRACKING_MODEL_KIND=ultraface_rfb_640

--- a/nuvion_app/inference/pipeline.py
+++ b/nuvion_app/inference/pipeline.py
@@ -1413,7 +1413,21 @@ class NuvionEventState:
             if frame is None or not self.face_tracking_enabled or self.tracking_controller is None:
                 continue
 
-            decision = self.tracking_controller.process_frame(frame)
+            try:
+                decision = self.tracking_controller.process_frame(frame)
+            except Exception as exc:
+                log.warning("[TRACK] face tracking inference failed: %s", exc)
+                error_text = f"TRACK error: {exc}"
+                self.tracking_overlay_state.update(
+                    TrackingOverlaySnapshot(
+                        enabled=self.face_tracking_enabled,
+                        show_bbox=False,
+                        status_text=error_text,
+                        updated_at=time.time(),
+                    )
+                )
+                self._set_tracking_status(error_text)
+                continue
             snapshot = build_overlay_snapshot(
                 decision,
                 enabled=self.face_tracking_enabled,

--- a/nuvion_app/runtime/model_guard.py
+++ b/nuvion_app/runtime/model_guard.py
@@ -65,6 +65,13 @@ def _is_raspberry_pi_linux() -> bool:
     return False
 
 
+def _is_jetson_linux() -> bool:
+    try:
+        return os.uname().sysname.lower() == "linux" and Path("/etc/nv_tegra_release").exists()
+    except Exception:
+        return False
+
+
 def _should_use_full_triton_profile() -> bool:
     return _is_darwin() or _is_raspberry_pi_linux()
 
@@ -132,6 +139,8 @@ def _pull_model(profile: str, model_dir: Path) -> None:
     anomaly_uses_triton = normalize_backend(os.getenv("NUVION_ZSAD_BACKEND", "triton"), default="triton") == "triton"
     tracking_uses_triton = face_tracking_uses_triton()
     optional_tracking_keys = _FACE_TRACKING_REQUIRED_KEYS if tracking_uses_triton else []
+    if tracking_uses_triton and _is_jetson_linux():
+        optional_tracking_keys = merge_required_keys(optional_tracking_keys, ["face_plan", "face_triton_config"])
 
     if not anomaly_uses_triton and tracking_uses_triton:
         ensure_default_face_tracking_model(model_dir)

--- a/nuvion_app/runtime/triton_manager.py
+++ b/nuvion_app/runtime/triton_manager.py
@@ -188,6 +188,42 @@ def _health_ready(host: str, port: int, timeout_sec: int) -> bool:
     return False
 
 
+def _model_ready(host: str, port: int, model_name: str, timeout_sec: int) -> bool:
+    url = f"http://{host}:{port}/v2/models/{model_name}/ready"
+    deadline = time.time() + timeout_sec
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                if 200 <= response.getcode() < 300:
+                    return True
+        except urllib.error.HTTPError:
+            return False
+        except urllib.error.URLError:
+            pass
+        except Exception:
+            pass
+        time.sleep(1)
+    return False
+
+
+def _required_models() -> list[str]:
+    models: list[str] = []
+    if normalize_backend(os.getenv("NUVION_ZSAD_BACKEND", "triton"), default="triton") == "triton":
+        models.append("image_encoder")
+    if face_tracking_uses_triton():
+        model_name = (os.getenv("NUVION_FACE_TRACKING_MODEL", "face_detector") or "face_detector").strip() or "face_detector"
+        if model_name not in models:
+            models.append(model_name)
+    return models
+
+
+def _required_models_ready(host: str, port: int, timeout_sec: int) -> bool:
+    for model_name in _required_models():
+        if not _model_ready(host, port, model_name, timeout_sec=timeout_sec):
+            return False
+    return True
+
+
 def _copy_if_needed(src: Path, dst: Path) -> None:
     dst.parent.mkdir(parents=True, exist_ok=True)
     if dst.exists() and dst.stat().st_size == src.stat().st_size:
@@ -236,30 +272,31 @@ def _ensure_face_detector_repository(model_dir: Path, repository_root: Path, *, 
     if not face_tracking_uses_triton():
         return
 
-    onnx_src = model_dir / "onnx" / "face_detector.onnx"
-    if not onnx_src.exists():
-        raise BootstrapError(
-            "triton_health_failed",
-            f"Missing face tracking ONNX model: {onnx_src}",
-        )
-
     config_src = model_dir / "triton" / "model_repository" / "face_detector" / "config.pbtxt"
     model_repo = repository_root / "face_detector" / "1"
     model_repo.mkdir(parents=True, exist_ok=True)
+    onnx_src = model_dir / "onnx" / "face_detector.onnx"
+    plan_path = model_repo / "model.plan"
+    packaged_plan = model_dir / "triton" / "model_repository" / "face_detector" / "1" / "model.plan"
 
     if prefer_tensorrt:
-        plan_path = model_repo / "model.plan"
-        packaged_plan = model_dir / "triton" / "model_repository" / "face_detector" / "1" / "model.plan"
         if packaged_plan.exists():
             _copy_if_needed(packaged_plan, plan_path)
-        elif not plan_path.exists() and not _build_face_detector_trt_plan(onnx_src, plan_path):
+            log.info("[TRACK] Using packaged TensorRT face detector plan: %s", packaged_plan)
+        elif not plan_path.exists() and onnx_src.exists() and not _build_face_detector_trt_plan(onnx_src, plan_path):
             _copy_if_needed(onnx_src, model_repo / "model.onnx")
             _write_face_detector_config_if_missing(
                 model_repo.parent / "config.pbtxt",
                 "onnxruntime_onnx",
                 None,
             )
+            log.warning("[TRACK] Falling back to ONNXRuntime face detector on Jetson because TensorRT plan build failed.")
             return
+        elif not plan_path.exists():
+            raise BootstrapError(
+                "triton_health_failed",
+                f"Missing face tracking TensorRT artifacts: {packaged_plan} (and no ONNX fallback at {onnx_src})",
+            )
 
         _write_face_detector_config_if_missing(
             model_repo.parent / "config.pbtxt",
@@ -268,6 +305,11 @@ def _ensure_face_detector_repository(model_dir: Path, repository_root: Path, *, 
         )
         return
 
+    if not onnx_src.exists():
+        raise BootstrapError(
+            "triton_health_failed",
+            f"Missing face tracking ONNX model: {onnx_src}",
+        )
     _copy_if_needed(onnx_src, model_repo / "model.onnx")
     _write_face_detector_config_if_missing(
         model_repo.parent / "config.pbtxt",
@@ -334,27 +376,31 @@ def ensure_triton_ready(stage: str, model_dir: Path) -> None:
     if local_only and host not in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}:
         return
 
+    repository = resolve_repository_for_runtime(model_dir).resolve()
+
     if _health_ready(host, port, timeout_sec=3):
-        _emit_progress(f"Triton 이미 준비됨: {host}:{port}")
-        return
+        if _required_models_ready(host, port, timeout_sec=3):
+            _emit_progress(f"Triton 이미 준비됨: {host}:{port}")
+            return
+        _emit_progress("Triton은 응답하지만 필요한 모델이 없어 컨테이너를 다시 올립니다.")
+        log.warning("[TRACK] Triton is healthy but required models are missing. Reloading container.")
 
     _emit_progress("Triton이 준비되지 않아 Docker/Triton 자동 복구를 시작합니다.")
     ensure_docker_ready(triton_url)
 
-    repository = resolve_repository_for_runtime(model_dir).resolve()
     container_name = os.getenv("NUVION_TRITON_CONTAINER_NAME", "triton-nuv").strip() or "triton-nuv"
     image = os.getenv("NUVION_TRITON_IMAGE", "nvcr.io/nvidia/tritonserver:24.10-py3").strip() or "nvcr.io/nvidia/tritonserver:24.10-py3"
 
     if container_exists(container_name):
         _emit_progress(f"기존 Triton 컨테이너 확인: {container_name}")
         if container_running(container_name):
-            if _health_ready(host, port, timeout_sec=5):
+            if _health_ready(host, port, timeout_sec=5) and _required_models_ready(host, port, timeout_sec=5):
                 _emit_progress("기존 Triton 컨테이너 재사용 성공")
                 return
             remove_container(container_name)
         else:
             start_container(container_name)
-            if _health_ready(host, port, timeout_sec=10):
+            if _health_ready(host, port, timeout_sec=10) and _required_models_ready(host, port, timeout_sec=10):
                 _emit_progress("중지된 Triton 컨테이너 재기동 성공")
                 _register_managed_triton_container(container_name)
                 return
@@ -373,6 +419,12 @@ def ensure_triton_ready(stage: str, model_dir: Path) -> None:
         raise BootstrapError(
             "triton_health_failed",
             f"Triton health check failed at http://{host}:{port}/v2/health/ready",
+        )
+    if not _required_models_ready(host, port, timeout_sec=10):
+        missing = ", ".join(_required_models()) or "unknown"
+        raise BootstrapError(
+            "triton_health_failed",
+            f"Triton started but required models are not ready: {missing}",
         )
     _register_managed_triton_container(container_name)
 

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.94}"
+VERSION="${VERSION:-0.1.95}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.94"
+  version "0.1.95"
   license "Proprietary"
 
   depends_on "python@3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.94"
+version = "0.1.95"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/agent/test_triton_face_client.py
+++ b/tests/agent/test_triton_face_client.py
@@ -21,6 +21,12 @@ class _FakeClient:
     def __init__(self, outputs: dict[str, np.ndarray]) -> None:
         self._outputs = outputs
 
+    def is_model_ready(self, **_kwargs):
+        return True
+
+    def get_model_metadata(self, **_kwargs):
+        return {"outputs": []}
+
     def infer(self, **_kwargs):
         return _FakeResponse(self._outputs)
 
@@ -39,6 +45,26 @@ class _FakeRequestedOutput:
 
 
 class TritonFaceClientTest(unittest.TestCase):
+    def test_init_fails_when_triton_model_is_not_ready(self) -> None:
+        fake_http = type(
+            "FakeHttpClient",
+            (),
+            {
+                "InferenceServerClient": lambda **_kwargs: type(
+                    "Client",
+                    (),
+                    {
+                        "is_model_ready": staticmethod(lambda **_kw: False),
+                        "get_model_metadata": staticmethod(lambda **_kw: {"outputs": []}),
+                    },
+                )(),
+            },
+        )
+
+        with mock.patch.object(face_client_module, "httpclient", fake_http):
+            with self.assertRaises(RuntimeError):
+                TritonFaceClient()
+
     def test_ultraface_scores_use_face_channel_and_decode_boxes(self) -> None:
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         priors = TritonFaceClient._ultraface_priors(640, 480)

--- a/tests/runtime/test_model_guard.py
+++ b/tests/runtime/test_model_guard.py
@@ -76,6 +76,28 @@ class ModelGuardTest(unittest.TestCase):
         ensure_face_model.assert_called_once()
         pull_server.assert_not_called()
 
+    def test_pull_model_requests_jetson_face_plan_as_optional_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "NUVION_ZSAD_BACKEND": "triton",
+                    "NUVION_FACE_TRACKING_ENABLED": "true",
+                    "NUVION_FACE_TRACKING_BACKEND": "triton",
+                    "NUVION_DEVICE_USERNAME": "device",
+                    "NUVION_DEVICE_PASSWORD": "secret",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(model_guard, "_is_jetson_linux", return_value=True):
+                    with mock.patch.object(model_guard, "pull_model_from_server") as pull_server:
+                        model_guard._pull_model("runtime", Path(tmp))
+
+        _, kwargs = pull_server.call_args
+        self.assertIn("face_onnx", kwargs["optional_keys"])
+        self.assertIn("face_plan", kwargs["optional_keys"])
+        self.assertIn("face_triton_config", kwargs["optional_keys"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runtime/test_triton_manager.py
+++ b/tests/runtime/test_triton_manager.py
@@ -99,6 +99,58 @@ class TritonManagerTest(unittest.TestCase):
             config = (resolved / "face_detector" / "config.pbtxt").read_text()
             self.assertIn('platform: "onnxruntime_onnx"', config)
 
+    def test_resolve_repository_jetson_uses_packaged_face_plan_without_onnx(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            default_repo = model_dir / "triton" / "model_repository"
+            (default_repo / "image_encoder" / "1").mkdir(parents=True, exist_ok=True)
+            packaged_plan = model_dir / "triton" / "model_repository" / "face_detector" / "1" / "model.plan"
+            packaged_plan.parent.mkdir(parents=True, exist_ok=True)
+            packaged_plan.write_bytes(b"trt-plan")
+
+            with mock.patch.object(triton_manager, "_should_use_onnx_repository", return_value=False):
+                with mock.patch.object(triton_manager, "_is_jetson_linux", return_value=True):
+                    with mock.patch.object(triton_manager, "face_tracking_uses_triton", return_value=True):
+                        resolved = triton_manager.resolve_repository_for_runtime(model_dir)
+
+            self.assertEqual(resolved, default_repo)
+            self.assertTrue((resolved / "face_detector" / "1" / "model.plan").exists())
+            config = (resolved / "face_detector" / "config.pbtxt").read_text()
+            self.assertIn('platform: "tensorrt_plan"', config)
+
+    def test_ensure_triton_ready_reloads_when_face_model_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            repo = model_dir / "triton" / "model_repository"
+            (repo / "image_encoder" / "1").mkdir(parents=True, exist_ok=True)
+            (model_dir / "onnx").mkdir(parents=True, exist_ok=True)
+            (model_dir / "onnx" / "face_detector.onnx").write_bytes(b"face")
+
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    "NUVION_ZSAD_BACKEND": "triton",
+                    "NUVION_FACE_TRACKING_ENABLED": "true",
+                    "NUVION_FACE_TRACKING_BACKEND": "triton",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(triton_manager, "_should_use_onnx_repository", return_value=False):
+                    with mock.patch.object(triton_manager, "_is_jetson_linux", return_value=True):
+                        with mock.patch.object(triton_manager, "ensure_docker_ready"):
+                            with mock.patch.object(triton_manager, "container_exists", return_value=True):
+                                with mock.patch.object(triton_manager, "container_running", return_value=True):
+                                    with mock.patch.object(triton_manager, "_health_ready", side_effect=[True, True, True]):
+                                        with mock.patch.object(triton_manager, "_required_models_ready", side_effect=[False, False, True]):
+                                            with mock.patch.object(triton_manager, "remove_container") as remove_mock:
+                                                with mock.patch.object(triton_manager, "run_triton_container") as run_mock:
+                                                    with mock.patch.object(triton_manager, "_register_managed_triton_container"):
+                                                        with mock.patch.object(triton_manager, "_build_face_detector_trt_plan", return_value=False):
+                                                            triton_manager.ensure_triton_ready("run", model_dir)
+
+            remove_mock.assert_called_once_with("triton-nuv")
+            run_mock.assert_called_once()
+
     def test_cleanup_managed_triton_stops_running_container(self) -> None:
         triton_manager._managed_triton_container = "triton-nuv"
         with mock.patch.object(triton_manager, "container_exists", return_value=True):


### PR DESCRIPTION
## Summary
- make Jetson face tracking prefer packaged TensorRT face detector artifacts and reload Triton when required models are missing
- fail Triton face client initialization early when `face_detector` is not actually ready
- surface tracking inference failures instead of letting the tracking worker die silently
- bump nuv-agent version to 0.1.95

## Why
Jetson Nano devices could download the face detector artifact but still run without an active `face_detector` model in Triton. That left anomaly inference alive while face tracking appeared enabled but did nothing.

## Impact
Jetson devices now validate that Triton has loaded both required models before reuse, and face tracking uses TensorRT-first assets when available.

## Validation
- `python -m py_compile nuvion_app/runtime/triton_manager.py nuvion_app/agent/triton_face_client.py nuvion_app/inference/pipeline.py nuvion_app/runtime/model_guard.py`
- `python -m unittest tests.runtime.test_triton_manager tests.runtime.test_model_guard tests.agent.test_triton_face_client`
