### PR TITLE
[codex] Fix Triton face detector model config

### DIFF
--- a/nuvion_app/runtime/triton_manager.py
+++ b/nuvion_app/runtime/triton_manager.py
@@ -43,13 +43,34 @@ instance_group [
 
 def _default_face_tracking_config(platform: str) -> str:
     model_name = (os.getenv("NUVION_FACE_TRACKING_MODEL", "face_detector") or "face_detector").strip() or "face_detector"
-    input_name = (os.getenv("NUVION_FACE_TRACKING_INPUT_NAME", "images") or "images").strip() or "images"
-    boxes_output = (os.getenv("NUVION_FACE_TRACKING_BOXES_OUTPUT", "detection_boxes") or "detection_boxes").strip() or "detection_boxes"
-    scores_output = (os.getenv("NUVION_FACE_TRACKING_SCORES_OUTPUT", "detection_scores") or "detection_scores").strip() or "detection_scores"
-    num_output = (os.getenv("NUVION_FACE_TRACKING_NUM_DETECTIONS_OUTPUT", "num_detections") or "num_detections").strip() or "num_detections"
+    input_name = (os.getenv("NUVION_FACE_TRACKING_INPUT_NAME", "input") or "input").strip() or "input"
+    boxes_output = (os.getenv("NUVION_FACE_TRACKING_BOXES_OUTPUT", "boxes") or "boxes").strip() or "boxes"
+    scores_output = (os.getenv("NUVION_FACE_TRACKING_SCORES_OUTPUT", "scores") or "scores").strip() or "scores"
+    num_output = (os.getenv("NUVION_FACE_TRACKING_NUM_DETECTIONS_OUTPUT", "") or "").strip()
     width = max(int(os.getenv("NUVION_FACE_TRACKING_INPUT_WIDTH", "640") or "640"), 1)
     height = max(int(os.getenv("NUVION_FACE_TRACKING_INPUT_HEIGHT", "640") or "640"), 1)
     instance_kind = "KIND_CPU" if platform == "onnxruntime_onnx" else "KIND_GPU"
+    output_blocks = [
+        f"""  {{
+    name: "{boxes_output}"
+    data_type: TYPE_FP32
+    dims: [ -1, 4 ]
+  }}""",
+        f"""  {{
+    name: "{scores_output}"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }}""",
+    ]
+    if num_output:
+        output_blocks.append(
+            f"""  {{
+    name: "{num_output}"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }}"""
+        )
+    outputs = ",\n".join(output_blocks)
     return f"""name: "{model_name}"
 platform: "{platform}"
 max_batch_size: 0
@@ -62,21 +83,7 @@ input [
   }}
 ]
 output [
-  {{
-    name: "{boxes_output}"
-    data_type: TYPE_FP32
-    dims: [ -1, 4 ]
-  }},
-  {{
-    name: "{scores_output}"
-    data_type: TYPE_FP32
-    dims: [ -1 ]
-  }},
-  {{
-    name: "{num_output}"
-    data_type: TYPE_INT32
-    dims: [ 1 ]
-  }}
+{outputs}
 ]
 instance_group [
   {{
@@ -233,7 +240,11 @@ def _copy_if_needed(src: Path, dst: Path) -> None:
 
 def _write_face_detector_config_if_missing(target_config: Path, platform: str, config_src: Path | None = None) -> None:
     target_config.parent.mkdir(parents=True, exist_ok=True)
-    if config_src is not None and config_src.exists():
+    if (
+        config_src is not None
+        and config_src.exists()
+        and config_src.resolve() != target_config.resolve()
+    ):
         _copy_if_needed(config_src, target_config)
         return
     target_config.write_text(_default_face_tracking_config(platform))

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.95}"
+VERSION="${VERSION:-0.1.96}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.95"
+  version "0.1.96"
   license "Proprietary"
 
   depends_on "python@3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.95"
+version = "0.1.96"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/runtime/test_triton_manager.py
+++ b/tests/runtime/test_triton_manager.py
@@ -12,6 +12,13 @@ class TritonManagerTest(unittest.TestCase):
     def tearDown(self) -> None:
         triton_manager._managed_triton_container = None
 
+    def test_default_face_tracking_config_matches_ultraface_io(self) -> None:
+        config = triton_manager._default_face_tracking_config("onnxruntime_onnx")
+        self.assertIn('name: "input"', config)
+        self.assertIn('name: "boxes"', config)
+        self.assertIn('name: "scores"', config)
+        self.assertNotIn('name: "num_detections"', config)
+
     def test_resolve_repository_uses_default_on_linux(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp) / "triton" / "model_repository"
@@ -79,6 +86,10 @@ class TritonManagerTest(unittest.TestCase):
             config = (resolved / "face_detector" / "config.pbtxt").read_text()
             self.assertIn('platform: "onnxruntime_onnx"', config)
             self.assertIn('name: "face_detector"', config)
+            self.assertIn('name: "input"', config)
+            self.assertIn('name: "boxes"', config)
+            self.assertIn('name: "scores"', config)
+            self.assertNotIn('name: "num_detections"', config)
 
     def test_resolve_repository_jetson_face_detector_falls_back_to_onnx_when_plan_build_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -98,6 +109,26 @@ class TritonManagerTest(unittest.TestCase):
             self.assertTrue((resolved / "face_detector" / "1" / "model.onnx").exists())
             config = (resolved / "face_detector" / "config.pbtxt").read_text()
             self.assertIn('platform: "onnxruntime_onnx"', config)
+
+    def test_resolve_repository_rewrites_stale_face_config_in_default_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            default_repo = model_dir / "triton" / "model_repository"
+            stale_config = default_repo / "face_detector" / "config.pbtxt"
+            stale_config.parent.mkdir(parents=True, exist_ok=True)
+            stale_config.write_text('name: "face_detector"\ninput [{ name: "images" }]\n')
+            (model_dir / "onnx").mkdir(parents=True, exist_ok=True)
+            (model_dir / "onnx" / "face_detector.onnx").write_bytes(b"face")
+
+            with mock.patch.object(triton_manager, "_should_use_onnx_repository", return_value=False):
+                with mock.patch.object(triton_manager, "_is_jetson_linux", return_value=True):
+                    with mock.patch.object(triton_manager, "face_tracking_uses_triton", return_value=True):
+                        with mock.patch.object(triton_manager, "_build_face_detector_trt_plan", return_value=False):
+                            triton_manager.resolve_repository_for_runtime(model_dir)
+
+            config = stale_config.read_text()
+            self.assertIn('name: "input"', config)
+            self.assertNotIn('name: "images"', config)
 
     def test_resolve_repository_jetson_uses_packaged_face_plan_without_onnx(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- fix the default Triton face detector config to use the UltraFace ONNX I/O names actually present in the model
- rewrite stale face detector configs in the runtime repository so Jetson upgrades do not keep the broken `images` input name
- bump nuv-agent version to 0.1.96

## Why
The 0.1.95 Jetson face tracking release could still fail during bootstrap because Triton loaded `face_detector` with an invalid config. That left the package half-configured on upgrade and kept the agent from starting.

## Validation
- `python -m py_compile nuvion_app/runtime/triton_manager.py`
- `python -m unittest tests.runtime.test_triton_manager tests.runtime.test_model_guard tests.agent.test_triton_face_client`
