### PR TITLE
[codex] Fix UltraFace Triton tensor shapes

### DIFF
--- a/nuvion_app/runtime/triton_manager.py
+++ b/nuvion_app/runtime/triton_manager.py
@@ -41,28 +41,69 @@ instance_group [
 """
 
 
+def _ultraface_box_count(width: int, height: int) -> int:
+    min_boxes = ((10.0, 16.0, 24.0), (32.0, 48.0), (64.0, 96.0), (128.0, 192.0, 256.0))
+    strides = (8.0, 16.0, 32.0, 64.0)
+    total = 0
+    for min_sizes, stride in zip(min_boxes, strides):
+        feature_map_w = int((width + stride - 1) // stride)
+        feature_map_h = int((height + stride - 1) // stride)
+        total += feature_map_w * feature_map_h * len(min_sizes)
+    return total
+
+
 def _default_face_tracking_config(platform: str) -> str:
     model_name = (os.getenv("NUVION_FACE_TRACKING_MODEL", "face_detector") or "face_detector").strip() or "face_detector"
     input_name = (os.getenv("NUVION_FACE_TRACKING_INPUT_NAME", "input") or "input").strip() or "input"
     boxes_output = (os.getenv("NUVION_FACE_TRACKING_BOXES_OUTPUT", "boxes") or "boxes").strip() or "boxes"
     scores_output = (os.getenv("NUVION_FACE_TRACKING_SCORES_OUTPUT", "scores") or "scores").strip() or "scores"
     num_output = (os.getenv("NUVION_FACE_TRACKING_NUM_DETECTIONS_OUTPUT", "") or "").strip()
+    model_kind = (os.getenv("NUVION_FACE_TRACKING_MODEL_KIND", "ultraface_rfb_640") or "ultraface_rfb_640").strip().lower()
     width = max(int(os.getenv("NUVION_FACE_TRACKING_INPUT_WIDTH", "640") or "640"), 1)
-    height = max(int(os.getenv("NUVION_FACE_TRACKING_INPUT_HEIGHT", "640") or "640"), 1)
+    height = max(int(os.getenv("NUVION_FACE_TRACKING_INPUT_HEIGHT", "480") or "480"), 1)
     instance_kind = "KIND_CPU" if platform == "onnxruntime_onnx" else "KIND_GPU"
-    output_blocks = [
-        f"""  {{
+    use_fixed_ultraface_shapes = model_kind.startswith("ultraface")
+
+    if use_fixed_ultraface_shapes:
+        input_block = f"""  {{
+    name: "{input_name}"
+    data_type: TYPE_FP32
+    dims: [ 1, 3, {height}, {width} ]
+  }}"""
+        box_count = _ultraface_box_count(width, height)
+        output_blocks = [
+            f"""  {{
+    name: "{scores_output}"
+    data_type: TYPE_FP32
+    dims: [ 1, {box_count}, 2 ]
+  }}""",
+            f"""  {{
+    name: "{boxes_output}"
+    data_type: TYPE_FP32
+    dims: [ 1, {box_count}, 4 ]
+  }}""",
+        ]
+    else:
+        input_block = f"""  {{
+    name: "{input_name}"
+    data_type: TYPE_FP32
+    dims: [ 3, {height}, {width} ]
+    format: FORMAT_NCHW
+  }}"""
+        output_blocks = [
+            f"""  {{
     name: "{boxes_output}"
     data_type: TYPE_FP32
     dims: [ -1, 4 ]
   }}""",
-        f"""  {{
+            f"""  {{
     name: "{scores_output}"
     data_type: TYPE_FP32
     dims: [ -1 ]
   }}""",
-    ]
-    if num_output:
+        ]
+
+    if num_output and not use_fixed_ultraface_shapes:
         output_blocks.append(
             f"""  {{
     name: "{num_output}"
@@ -75,12 +116,7 @@ def _default_face_tracking_config(platform: str) -> str:
 platform: "{platform}"
 max_batch_size: 0
 input [
-  {{
-    name: "{input_name}"
-    data_type: TYPE_FP32
-    dims: [ 3, {height}, {width} ]
-    format: FORMAT_NCHW
-  }}
+{input_block}
 ]
 output [
 {outputs}

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.96}"
+VERSION="${VERSION:-0.1.97}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.96"
+  version "0.1.97"
   license "Proprietary"
 
   depends_on "python@3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.96"
+version = "0.1.97"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/runtime/test_triton_manager.py
+++ b/tests/runtime/test_triton_manager.py
@@ -14,10 +14,13 @@ class TritonManagerTest(unittest.TestCase):
 
     def test_default_face_tracking_config_matches_ultraface_io(self) -> None:
         config = triton_manager._default_face_tracking_config("onnxruntime_onnx")
-        self.assertIn('name: "input"', config)
-        self.assertIn('name: "boxes"', config)
         self.assertIn('name: "scores"', config)
+        self.assertIn('name: "boxes"', config)
+        self.assertIn('dims: [ 1, 3, 480, 640 ]', config)
+        self.assertIn('dims: [ 1, 17640, 2 ]', config)
+        self.assertIn('dims: [ 1, 17640, 4 ]', config)
         self.assertNotIn('name: "num_detections"', config)
+        self.assertNotIn('format: FORMAT_NCHW', config)
 
     def test_resolve_repository_uses_default_on_linux(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -87,8 +90,11 @@ class TritonManagerTest(unittest.TestCase):
             self.assertIn('platform: "onnxruntime_onnx"', config)
             self.assertIn('name: "face_detector"', config)
             self.assertIn('name: "input"', config)
-            self.assertIn('name: "boxes"', config)
             self.assertIn('name: "scores"', config)
+            self.assertIn('name: "boxes"', config)
+            self.assertIn('dims: [ 1, 3, 480, 640 ]', config)
+            self.assertIn('dims: [ 1, 17640, 2 ]', config)
+            self.assertIn('dims: [ 1, 17640, 4 ]', config)
             self.assertNotIn('name: "num_detections"', config)
 
     def test_resolve_repository_jetson_face_detector_falls_back_to_onnx_when_plan_build_fails(self) -> None:


### PR DESCRIPTION
## Summary
- fix the generated Triton config for UltraFace so the input and output tensor shapes match the actual ONNX model
- align the runtime default input height with the shipped UltraFace 640x480 model
- bump nuv-agent version to 0.1.97

## Why
The previous Jetson hotfix still left `face_detector` unloadable in Triton because the generated model config used a 3D input and generic output shapes, while the shipped UltraFace model expects fixed shapes.

## Validation
- `python -m py_compile nuvion_app/runtime/triton_manager.py`
- `python -m unittest tests.runtime.test_triton_manager`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 얼굴 감지 모델의 입력 처리가 최적화되었으며, 기본 입력 높이가 조정되었습니다.
  * Ultraface 모델에 대한 고정 입력 형식 및 출력 차원 지원이 강화되었습니다.
  * 모델 감지 설정에서 환경 변수를 통한 모델 종류 선택이 개선되었습니다.

* **기타**
  * 패키지 버전이 0.1.97로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->