### PR TITLE
Fix Jetson face artifact permission handling

### DIFF
--- a/nuvion_app/runtime/triton_manager.py
+++ b/nuvion_app/runtime/triton_manager.py
@@ -317,6 +317,15 @@ def _copy_if_needed(src: Path, dst: Path) -> None:
 
 def _write_face_detector_config_if_missing(target_config: Path, platform: str, config_src: Path | None = None) -> None:
     target_config.parent.mkdir(parents=True, exist_ok=True)
+    desired_content = _default_face_tracking_config(platform)
+    if target_config.exists():
+        if config_src is None or not config_src.exists() or config_src.resolve() == target_config.resolve():
+            try:
+                existing_content = target_config.read_text()
+            except OSError:
+                existing_content = None
+            if existing_content == desired_content:
+                return
     if (
         config_src is not None
         and config_src.exists()
@@ -324,7 +333,7 @@ def _write_face_detector_config_if_missing(target_config: Path, platform: str, c
     ):
         _copy_if_needed(config_src, target_config)
         return
-    target_config.write_text(_default_face_tracking_config(platform))
+    target_config.write_text(desired_content)
 
 
 def _build_face_detector_trt_plan(onnx_src: Path, plan_dst: Path) -> bool:

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.99}"
+VERSION="${VERSION:-0.1.100}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.99"
+  version "0.1.100"
   license "Proprietary"
 
   depends_on "python@3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.99"
+version = "0.1.100"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/runtime/test_triton_manager.py
+++ b/tests/runtime/test_triton_manager.py
@@ -157,6 +157,18 @@ class TritonManagerTest(unittest.TestCase):
             config = (resolved / "face_detector" / "config.pbtxt").read_text()
             self.assertIn('platform: "tensorrt_plan"', config)
 
+    def test_write_face_detector_config_if_missing_keeps_matching_existing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "face_detector" / "config.pbtxt"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(triton_manager._default_face_tracking_config("tensorrt_plan"))
+
+            before = config_path.read_text()
+            triton_manager._write_face_detector_config_if_missing(config_path, "tensorrt_plan", config_path)
+            after = config_path.read_text()
+
+        self.assertEqual(before, after)
+
     def test_prepare_face_detector_onnx_for_runtime_marks_batch_dimension_dynamic(self) -> None:
         try:
             import onnx


### PR DESCRIPTION
## Summary
- avoid rewriting an existing matching face detector Triton config in-place
- keep stale config rewrite behavior for genuinely mismatched files
- bump version to 0.1.100 for the Jetson bootstrap hotfix

## Testing
- python -m unittest tests.runtime.test_triton_manager tests.runtime.test_model_guard tests.inference.test_face_tracking


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 기존 설정 파일이 원하는 내용과 일치할 때 불필요한 재작성 방지

* **테스트**
  * 기존 설정 파일이 변경되지 않음을 검증하는 새로운 테스트 추가

* **기타**
  * 패키지 버전을 0.1.99에서 0.1.100으로 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->