### PR TITLE
[NUV-447] fix: agent stomp error queue 경로 정규화

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ For dev, `.env` in the repo is used automatically.
 macOS note: use `NUVION_VIDEO_SOURCE=avf` (default camera) or `avf:<index>` to select a camera.
 
 ### Agent WebSocket error queue
-- Agent는 STOMP에서 `/user/queue/agent/error`를 구독합니다.
+- Agent는 STOMP에서 `/user/queue/agent.error`를 구독합니다.
 - `retryable=true` 에러는 마지막 uplink payload(`/app/device/*`, `/app/broadcast/start`)를 백오프로 재전송합니다.
 - `401/403` 같은 non-retryable 권한 오류는 uplink를 차단하고 로그에 원인(`code`, `path`, `detail`)을 남깁니다.
 

--- a/nuvion_app/config_template.env
+++ b/nuvion_app/config_template.env
@@ -160,7 +160,7 @@ NUVION_CLIP_SEGMENT_MIN_SIZE_BYTES=65536
 # NUVION_FFMPEG_PATH=/opt/homebrew/bin/ffmpeg
 # NUVION_FFPROBE_PATH=/opt/homebrew/bin/ffprobe
 
-# Agent WebSocket error handling (server /user/queue/agent/error)
+# Agent WebSocket error handling (server /user/queue/agent.error)
 NUVION_AGENT_ERROR_MAX_RETRIES=3
 NUVION_AGENT_ERROR_BACKOFF_BASE_SEC=1.0
 NUVION_AGENT_ERROR_BACKOFF_MAX_SEC=15.0

--- a/nuvion_app/inference/pipeline.py
+++ b/nuvion_app/inference/pipeline.py
@@ -232,7 +232,7 @@ AGENT_ERROR_MAX_RETRIES = int(os.getenv("NUVION_AGENT_ERROR_MAX_RETRIES", "3"))
 AGENT_ERROR_BACKOFF_BASE_SEC = parse_float(os.getenv("NUVION_AGENT_ERROR_BACKOFF_BASE_SEC"), 1.0)
 AGENT_ERROR_BACKOFF_MAX_SEC = parse_float(os.getenv("NUVION_AGENT_ERROR_BACKOFF_MAX_SEC"), 15.0)
 
-AGENT_ERROR_QUEUE_DEST = "/user/queue/agent/error"
+AGENT_ERROR_QUEUE_DEST = "/user/queue/agent.error"
 AGENT_COMMAND_QUEUE_DEST = "/user/queue/command"
 AGENT_RETRY_DESTINATIONS = {
     "/app/device/anomaly",


### PR DESCRIPTION
## Summary
- agent error queue subscribe destination을 relay-friendly naming으로 변경
- README와 config template의 경로 설명을 동일 규칙으로 맞춤

## Verify
- python3 -m compileall nuvion_app/inference/pipeline.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- Agent 에러 큐의 WebSocket 구독 경로가 수정되어 에러 메시지 라우팅의 정확성이 향상되었습니다.

## 문서
- 에러 핸들링 엔드포인트 경로에 대한 설명서와 설정 템플릿이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->