### PR TITLE
[NUV-447] fix: empty uplink ice candidate 전송 방지

### DIFF
--- a/nuvion_app/inference/webrtc_uplink.py
+++ b/nuvion_app/inference/webrtc_uplink.py
@@ -222,11 +222,19 @@ class WebRTCUplinkController:
     def _on_ice_candidate(self, _element: Gst.Element, mline_index: int, candidate: str) -> None:
         if not self._session:
             return
+        candidate_text = str(candidate or "").strip()
+        if not candidate_text:
+            log.debug(
+                "[WEBRTC-UPLINK] skip empty local ICE candidate. sessionId=%s mline=%s",
+                self._session.session_id,
+                mline_index,
+            )
+            return
         payload = build_uplink_payload(
             WEBRTC_UPLINK_ICE_CANDIDATE,
             self._session.broadcast_id,
             self._session.session_id,
-            candidate=candidate,
+            candidate=candidate_text,
             sdpMLineIndex=int(mline_index),
             sdpMid="video",
         )

--- a/tests/inference/test_webrtc_uplink.py
+++ b/tests/inference/test_webrtc_uplink.py
@@ -84,6 +84,26 @@ class WebRTCUplinkControllerTest(unittest.TestCase):
 
         self.assertEqual(len(_FakeGLib.calls), 1)
 
+    def test_on_ice_candidate_skips_empty_candidate(self) -> None:
+        sent_messages: list[tuple[str, dict[str, object], bool]] = []
+
+        def send_message(destination: str, payload: dict[str, object], remember: bool) -> bool:
+            sent_messages.append((destination, payload, remember))
+            return True
+
+        controller = self.module.WebRTCUplinkController(send_message=send_message)
+        controller._session = self.module.WebRTCUplinkSession(
+            broadcast_id="device-1",
+            session_id="session-1",
+            force_relay=False,
+            ice_servers=[],
+        )
+
+        controller._on_ice_candidate(None, 0, "")
+        controller._on_ice_candidate(None, 0, "   ")
+
+        self.assertEqual(sent_messages, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- agent uplink local ICE candidate가 비어 있을 때 서버로 보내지 않도록 처리
- uplink ICE candidate 관련 단위 테스트 추가

## Verify
- python3 -m unittest tests.inference.test_webrtc_uplink -v
