### PR TITLE
[NUV-447] fix: stomp heartbeat sender 추가

### DIFF
--- a/nuvion_app/inference/pipeline.py
+++ b/nuvion_app/inference/pipeline.py
@@ -49,6 +49,7 @@ from nuvion_app.inference.webrtc_signaling import (
     WEBRTC_UPLINK_START,
     WEBRTC_UPLINK_STATE,
     WEBRTC_UPLINK_STOP_DEST,
+    negotiate_stomp_send_interval_ms,
     parse_command_payload,
 )
 from nuvion_app.inference.webrtc_uplink import WebRTCUplinkController
@@ -616,6 +617,26 @@ async def outbound_sender(ws: websockets.WebSocketClientProtocol):
             log.warning("[STOMP] send failed: %s", exc)
 
 
+async def stomp_heartbeat_sender(
+    ws: websockets.WebSocketClientProtocol,
+    send_interval_ms: int | None,
+):
+    if not send_interval_ms or send_interval_ms <= 0:
+        log.info("[SIGNALING] STOMP heartbeat sender disabled.")
+        return
+
+    interval_sec = max(send_interval_ms / 1000.0, 1.0)
+    log.info("[SIGNALING] STOMP heartbeat sender enabled. interval_ms=%s", send_interval_ms)
+
+    while True:
+        await asyncio.sleep(interval_sec)
+        try:
+            await ws.send(json.dumps(["\n"]))
+        except Exception as exc:
+            log.warning("[SIGNALING] STOMP heartbeat send failed: %s", exc)
+            raise
+
+
 async def device_state_heartbeat_sender():
     interval = max(1.0, DEVICE_STATE_INTERVAL_SEC)
     while True:
@@ -852,12 +873,20 @@ async def signaling_client_main():
                 if "CONNECTED" not in raw:
                     raise ConnectionError("STOMP CONNECT failed")
 
+                connected_frame = stomper.unpack_frame(raw)
+                connected_headers = connected_frame.get("headers", {}) if isinstance(connected_frame, dict) else {}
+                send_interval_ms = negotiate_stomp_send_interval_ms(
+                    10_000,
+                    connected_headers.get("heart-beat"),
+                )
+
                 log.info("[SIGNALING] ✅ STOMP CONNECTED.")
 
                 await ws.send(json.dumps([stomper.subscribe(AGENT_COMMAND_QUEUE_DEST, "sub-command")]))
                 await ws.send(json.dumps([stomper.subscribe(AGENT_ERROR_QUEUE_DEST, "sub-agent-error")]))
 
                 sender_task = asyncio.create_task(outbound_sender(ws))
+                stomp_heartbeat_task = asyncio.create_task(stomp_heartbeat_sender(ws, send_interval_ms))
                 heartbeat_task = asyncio.create_task(device_state_heartbeat_sender())
                 connectivity_task = None
                 if CONNECTIVITY_ENABLED:
@@ -880,6 +909,8 @@ async def signaling_client_main():
                         continue
                     frame_list = json.loads(message[1:])
                     for frame_str in frame_list:
+                        if isinstance(frame_str, str) and not frame_str.strip():
+                            continue
                         frame = stomper.unpack_frame(frame_str)
                         destination = frame["headers"].get("destination")
                         body = frame["body"]
@@ -895,6 +926,8 @@ async def signaling_client_main():
             websocket = None
             if "sender_task" in locals():
                 sender_task.cancel()
+            if "stomp_heartbeat_task" in locals():
+                stomp_heartbeat_task.cancel()
             if "heartbeat_task" in locals():
                 heartbeat_task.cancel()
             if "connectivity_task" in locals() and connectivity_task is not None:

--- a/nuvion_app/inference/webrtc_signaling.py
+++ b/nuvion_app/inference/webrtc_signaling.py
@@ -146,3 +146,34 @@ def build_uplink_payload(
     }
     payload.update(extra)
     return payload
+
+
+def parse_stomp_heartbeat_header(value: Any) -> tuple[int, int]:
+    if not isinstance(value, str):
+        return 0, 0
+
+    parts = [part.strip() for part in value.split(",", 1)]
+    if len(parts) != 2:
+        return 0, 0
+
+    try:
+        can_send = int(parts[0])
+        wants_receive = int(parts[1])
+    except ValueError:
+        return 0, 0
+
+    return max(0, can_send), max(0, wants_receive)
+
+
+def negotiate_stomp_send_interval_ms(
+    client_can_send_ms: int,
+    server_heartbeat_header: Any,
+) -> int | None:
+    if client_can_send_ms <= 0:
+        return None
+
+    _server_can_send_ms, server_wants_receive_ms = parse_stomp_heartbeat_header(server_heartbeat_header)
+    if server_wants_receive_ms <= 0:
+        return None
+
+    return max(client_can_send_ms, server_wants_receive_ms)

--- a/tests/inference/test_webrtc_signaling.py
+++ b/tests/inference/test_webrtc_signaling.py
@@ -4,7 +4,9 @@ import unittest
 
 from nuvion_app.inference.webrtc_signaling import (
     UPLINK_MODE_WEBRTC,
+    negotiate_stomp_send_interval_ms,
     normalize_uplink_mode,
+    parse_stomp_heartbeat_header,
     parse_ice_servers,
     to_gst_ice_server_config,
 )
@@ -42,6 +44,17 @@ class WebRTCSignalingTest(unittest.TestCase):
                 "turn://1700000000%3Adevice-1:c2VjcmV0Og%3D%3D@stunner.example.com:3478?transport=udp",
             ],
         )
+
+    def test_parse_stomp_heartbeat_header(self) -> None:
+        self.assertEqual(parse_stomp_heartbeat_header("10000,10000"), (10000, 10000))
+        self.assertEqual(parse_stomp_heartbeat_header("0,0"), (0, 0))
+        self.assertEqual(parse_stomp_heartbeat_header(None), (0, 0))
+        self.assertEqual(parse_stomp_heartbeat_header("bad"), (0, 0))
+
+    def test_negotiate_stomp_send_interval_ms(self) -> None:
+        self.assertEqual(negotiate_stomp_send_interval_ms(10000, "10000,10000"), 10000)
+        self.assertEqual(negotiate_stomp_send_interval_ms(10000, "0,15000"), 15000)
+        self.assertIsNone(negotiate_stomp_send_interval_ms(10000, "10000,0"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- STOMP CONNECT heart-beat 협상값을 해석해 client heartbeat를 실제로 전송
- SockJS heartbeat frame을 무시하도록 signaling loop 정리
- 관련 signaling helper 테스트 추가

## Verify
- PYTHONPATH=. python3 -m unittest tests.inference.test_webrtc_signaling tests.inference.test_webrtc_uplink -v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * STOMP 신호 프로토콜에서 서버 하트비트 협상 기능 추가
  * 백그라운드 하트비트 전송 메커니즘 구현으로 연결 안정성 개선

* **버그 수정**
  * 메시지 처리 루프에서 불필요한 빈 프레임 무시 처리 개선

* **테스트**
  * 하트비트 협상 및 파싱 로직에 대한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->