### PR TITLE
fix: strip browser turn query for gstreamer relay

### DIFF
--- a/nuvion_app/inference/webrtc_signaling.py
+++ b/nuvion_app/inference/webrtc_signaling.py
@@ -122,12 +122,14 @@ def to_gst_ice_server_config(ice_servers: list[dict[str, Any]]) -> tuple[str | N
             if not host:
                 continue
 
-            query = f"?{parsed.query}" if parsed.query else ""
             auth_prefix = ""
             if username and credential:
                 auth_prefix = f"{_quote_turn_username(username)}:{_quote_turn_password(credential)}@"
             turn_servers.append(
-                f"{_uri_scheme_prefix(parsed.scheme)}{auth_prefix}{host}:{port}{query}"
+                # webrtcbin expects turn(s)://username:password@host:port without browser-style
+                # query parameters such as ?transport=udp. Passing the query through prevents relay
+                # allocations on both macOS and Jetson runtimes.
+                f"{_uri_scheme_prefix(parsed.scheme)}{auth_prefix}{host}:{port}"
             )
 
     return stun_server, turn_servers

--- a/tests/inference/test_webrtc_signaling.py
+++ b/tests/inference/test_webrtc_signaling.py
@@ -41,7 +41,7 @@ class WebRTCSignalingTest(unittest.TestCase):
         self.assertEqual(
             turn_servers,
             [
-                "turn://1700000000%3Adevice-1:c2VjcmV0Og%3D%3D@stunner.example.com:3478?transport=udp",
+                "turn://1700000000%3Adevice-1:c2VjcmV0Og%3D%3D@stunner.example.com:3478",
             ],
         )
 


### PR DESCRIPTION
## Summary
- strip browser-style ?transport=udp query params when converting TURN URLs for GStreamer webrtcbin
- keep browser ICE server JSON unchanged while producing a GStreamer-compatible turn-server URI
- add/update tests for TURN URI normalization

## Validation
- PYTHONPATH=. python3 -m unittest tests.inference.test_webrtc_signaling tests.inference.test_webrtc_uplink -v