### PR TITLE
chore(release): 0.1.111

### DIFF
--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.110}"
+VERSION="${VERSION:-0.1.111}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.110"
+  version "0.1.111"
   license "Proprietary"
 
   depends_on "python@3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.110"
+version = "0.1.111"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump nuv-agent package metadata to 0.1.111
- prepare Homebrew and DEB release metadata for the direct-first fallback default change

## Validation
- python -m unittest tests.test_config_video_sources tests.inference.test_webrtc_uplink
