### PR TITLE
fix: migrate nuvion agent endpoints to plaidlabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Python requirement: 3.10+
 # runtime: text_features + Triton model_repository (권장)
 nuv-agent pull-model \
   --source server \
-  --server-base-url https://api.nuvion-dev.plaidai.io \
+  --server-base-url https://api.nuvion-dev.plaidlabs.ai \
   --pointer anomalyclip/prod \
   --local-dir ~/.cache/nuvion/models/anomalyclip-current \
   --profile runtime
@@ -79,7 +79,7 @@ Profiles:
 기본값:
 - `NUVION_MODEL_POINTER=anomalyclip/prod`
 - `NUVION_MODEL_PRESIGN_TTL_SECONDS=300`
-- `NUVION_MODEL_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io`
+- `NUVION_MODEL_SERVER_BASE_URL=https://api.nuvion-dev.plaidlabs.ai`
 - `NUVION_MODEL_PROFILE=runtime`
 - `NUVION_MODEL_LOCAL_DIR=~/.cache/nuvion/models/anomalyclip-current`
 

--- a/nuvion_app/config_template.env
+++ b/nuvion_app/config_template.env
@@ -1,8 +1,8 @@
 # Config schema version (auto-migrated by `nuv-agent doctor --fix`)
-NUVION_CONFIG_SCHEMA_VERSION=8
+NUVION_CONFIG_SCHEMA_VERSION=9
 
 # Spring Boot 서버의 전체 주소
-NUVION_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io
+NUVION_SERVER_BASE_URL=https://api.nuvion-dev.plaidlabs.ai
 
 # Device 계정 (BROADCASTER 역할)
 NUVION_DEVICE_USERNAME=sp-<space>-nuvion-<random>
@@ -95,7 +95,7 @@ NUVION_CONNECTIVITY_POOR_RSSI_DBM=-80
 NUVION_CONNECTIVITY_POOR_PACKET_LOSS_PCT=8
 NUVION_CONNECTIVITY_POOR_RTT_MS=250
 # Optional overrides
-# NUVION_CONNECTIVITY_TARGET_HOST=api.nuvion-dev.plaidai.io
+# NUVION_CONNECTIVITY_TARGET_HOST=api.nuvion-dev.plaidlabs.ai
 # NUVION_WIFI_INTERFACE=wlan0
 
 # Zero-shot anomaly detection (optional)
@@ -135,7 +135,7 @@ NUVION_TRITON_JETSON_PROFILE=runtime
 # Models are downloaded via server-issued presigned URLs only.
 NUVION_MODEL_POINTER=anomalyclip/prod
 NUVION_MODEL_PRESIGN_TTL_SECONDS=300
-NUVION_MODEL_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io
+NUVION_MODEL_SERVER_BASE_URL=https://api.nuvion-dev.plaidlabs.ai
 # Optional: pre-issued bearer token. If omitted, setup-saved device credentials are used.
 # NUVION_MODEL_SERVER_ACCESS_TOKEN=
 NUVION_MODEL_PROFILE=runtime

--- a/nuvion_app/model_store.py
+++ b/nuvion_app/model_store.py
@@ -16,7 +16,7 @@ DEFAULT_MODEL_SOURCE = "server"
 DEFAULT_MODEL_PROFILE = "runtime"
 DEFAULT_MODEL_POINTER = "anomalyclip/prod"
 DEFAULT_MODEL_PRESIGN_TTL_SECONDS = 300
-DEFAULT_MODEL_SERVER_BASE_URL = "https://api.nuvion-dev.plaidai.io"
+DEFAULT_MODEL_SERVER_BASE_URL = "https://api.nuvion-dev.plaidlabs.ai"
 DEFAULT_MODEL_PRESIGN_REFRESH_RETRIES = 2
 DEFAULT_FACE_TRACKING_MODEL_URL = (
     "https://github.com/onnx/models/raw/main/validated/vision/body_analysis/ultraface/models/version-RFB-640.onnx"

--- a/nuvion_app/runtime/config_guard.py
+++ b/nuvion_app/runtime/config_guard.py
@@ -15,7 +15,16 @@ from nuvion_app.runtime.inference_mode import (
     normalize_siglip_device,
 )
 
-CURRENT_CONFIG_SCHEMA_VERSION = "8"
+CURRENT_CONFIG_SCHEMA_VERSION = "9"
+_LEGACY_HOST_REPLACEMENTS = {
+    "api.nuvion-dev.plaidai.io": "api.nuvion-dev.plaidlabs.ai",
+    "webrtc.nuvion-dev.plaidai.io": "webrtc.nuvion-dev.plaidlabs.ai",
+}
+_LEGACY_HOST_CONFIG_KEYS = (
+    "NUVION_SERVER_BASE_URL",
+    "NUVION_MODEL_SERVER_BASE_URL",
+    "NUVION_CONNECTIVITY_TARGET_HOST",
+)
 _VALID_MODEL_SOURCES = {"server"}
 _VALID_MODEL_PROFILES = {"runtime", "light", "full"}
 _VALID_TRITON_INPUT_FORMATS = {"NCHW", "NHWC"}
@@ -137,6 +146,14 @@ def _apply_migrations(values: Dict[str, str]) -> List[str]:
 
     if values.get("NUVION_CONFIG_SCHEMA_VERSION", "").strip() != CURRENT_CONFIG_SCHEMA_VERSION:
         update("NUVION_CONFIG_SCHEMA_VERSION", CURRENT_CONFIG_SCHEMA_VERSION, "schema version update")
+
+    for key in _LEGACY_HOST_CONFIG_KEYS:
+        old_value = values.get(key, "")
+        new_value = old_value
+        for legacy_host, current_host in _LEGACY_HOST_REPLACEMENTS.items():
+            new_value = new_value.replace(legacy_host, current_host)
+        if new_value != old_value:
+            update(key, new_value, "replace legacy Nuvion hostname")
 
     if previous_schema != CURRENT_CONFIG_SCHEMA_VERSION:
         legacy_responsiveness_defaults = {

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PKG_NAME="nuv-agent"
-VERSION="${VERSION:-0.1.111}"
+VERSION="${VERSION:-0.1.112}"
 ARCH="${ARCH:-$(dpkg --print-architecture)}"
 BUILD_ROOT="${BUILD_ROOT:-$(mktemp -d)}"
 

--- a/packaging/homebrew/nuv-agent.rb
+++ b/packaging/homebrew/nuv-agent.rb
@@ -5,7 +5,7 @@ class NuvAgent < Formula
   homepage "https://github.com/plaid-ai/NUV-agent"
   url "__URL__"
   sha256 "__SHA256__"
-  version "0.1.111"
+  version "0.1.112"
   license "Proprietary"
 
   depends_on "python@3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nuv-agent"
-version = "0.1.111"
+version = "0.1.112"
 description = "Nuvion on-device agent"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/runtime/test_config_guard.py
+++ b/tests/runtime/test_config_guard.py
@@ -36,6 +36,32 @@ class ConfigGuardTest(unittest.TestCase):
             self.assertEqual(report.values["NUVION_CONFIG_SCHEMA_VERSION"], CURRENT_CONFIG_SCHEMA_VERSION)
             self.assertGreater(len(report.changed), 0)
 
+    def test_guard_migrates_legacy_nuvion_hostnames(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "agent.env"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "NUVION_CONFIG_SCHEMA_VERSION=8",
+                        "NUVION_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io",
+                        "NUVION_MODEL_SERVER_BASE_URL=https://api.nuvion-dev.plaidai.io",
+                        "NUVION_CONNECTIVITY_TARGET_HOST=api.nuvion-dev.plaidai.io",
+                        "NUVION_DEVICE_USERNAME=device-1",
+                        "NUVION_DEVICE_PASSWORD=secret",
+                        "NUVION_ZSAD_BACKEND=none",
+                        "",
+                    ]
+                )
+            )
+
+            report = guard_config(config_path=config_path, apply_fixes=True)
+
+            self.assertTrue(report.ok)
+            self.assertEqual(report.values["NUVION_CONFIG_SCHEMA_VERSION"], CURRENT_CONFIG_SCHEMA_VERSION)
+            self.assertEqual(report.values["NUVION_SERVER_BASE_URL"], "https://api.nuvion-dev.plaidlabs.ai")
+            self.assertEqual(report.values["NUVION_MODEL_SERVER_BASE_URL"], "https://api.nuvion-dev.plaidlabs.ai")
+            self.assertEqual(report.values["NUVION_CONNECTIVITY_TARGET_HOST"], "api.nuvion-dev.plaidlabs.ai")
+
     def test_guard_detects_required_value_error(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             config_path = Path(tmp) / "agent.env"

--- a/tests/runtime/test_docker_manager.py
+++ b/tests/runtime/test_docker_manager.py
@@ -19,12 +19,12 @@ class DockerManagerTest(unittest.TestCase):
 
     def test_local_host(self) -> None:
         self.assertTrue(docker_manager.is_local_host("localhost"))
-        self.assertFalse(docker_manager.is_local_host("api.nuvion-dev.plaidai.io"))
+        self.assertFalse(docker_manager.is_local_host("api.nuvion-dev.plaidlabs.ai"))
 
     def test_skip_remote_host(self) -> None:
         with mock.patch.object(docker_manager, "_ensure_docker_cli_mac") as mac_cli:
             with mock.patch.object(docker_manager, "_ensure_docker_cli_linux") as linux_cli:
-                docker_manager.ensure_docker_ready("https://api.nuvion-dev.plaidai.io:8000")
+                docker_manager.ensure_docker_ready("https://api.nuvion-dev.plaidlabs.ai:8000")
                 mac_cli.assert_not_called()
                 linux_cli.assert_not_called()
 

--- a/tests/runtime/test_model_store_selfheal.py
+++ b/tests/runtime/test_model_store_selfheal.py
@@ -78,7 +78,7 @@ class ModelStoreSelfHealTest(unittest.TestCase):
                 with mock.patch.object(model_store, "_download_http_file", side_effect=fake_download) as dl_mock:
                     with mock.patch.object(model_store, "_validate_download_integrity", return_value=None):
                         target_dir, data = model_store.pull_model_from_server(
-                            server_base_url="https://api.nuvion-dev.plaidai.io",
+                            server_base_url="https://api.nuvion-dev.plaidlabs.ai",
                             pointer="anomalyclip/prod",
                             profile="light",
                             local_dir=tmp,


### PR DESCRIPTION
## Summary
- switch NUV-agent default Nuvion API/model endpoints to api.nuvion-dev.plaidlabs.ai
- add config schema migration for legacy plaidai.io hostnames
- bump package/formula/deb version to 0.1.112

## Test
- python -m unittest tests.runtime.test_config_guard tests.runtime.test_model_store_selfheal tests.runtime.test_docker_manager
- python -m build --sdist --outdir dist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경 사항

* **버그 수정**
  * 모델 서버 및 연결 엔드포인트 주소 업데이트로 안정성 개선

* **Chores**
  * 패키지 버전 업그레이드 (v0.1.112)
  * 구성 스키마 자동 마이그레이션 지원 (v8 → v9)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->